### PR TITLE
DSA4.1: Bugfix for readability of Charsheet labels and Rolltemplate Headers in Dark Mode

### DIFF
--- a/Das_Schwarze_Auge_4-1/dev/css/style.css
+++ b/Das_Schwarze_Auge_4-1/dev/css/style.css
@@ -1763,7 +1763,7 @@ upper left, upper right, lower right, lower left */
 
 /* Temporary fix until proper darkmode CSS is implemented */
 .sheet-darkmode .characterviewer label,
-html.dark th {
+.sheet-rolltemplate-darkmode table th {
     color: var(--color-foreground) !important;
 }
 

--- a/Das_Schwarze_Auge_4-1/dev/css/style.css
+++ b/Das_Schwarze_Auge_4-1/dev/css/style.css
@@ -1759,3 +1759,11 @@ upper left, upper right, lower right, lower left */
 	display: block;
 }
 
+/*--------------------------------------------Darkmode-------------------------------------*/
+
+/* Temporary fix until proper darkmode CSS is implemented */
+.sheet-darkmode .characterviewer label,
+html.dark th {
+    color: var(--color-foreground) !important;
+}
+

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -1763,7 +1763,7 @@ upper left, upper right, lower right, lower left */
 
 /* Temporary fix until proper darkmode CSS is implemented */
 .sheet-darkmode .characterviewer label,
-html.dark th {
+.sheet-rolltemplate-darkmode table th {
     color: var(--color-foreground) !important;
 }
 

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -1767,4 +1767,3 @@ html.dark th {
     color: var(--color-foreground) !important;
 }
 
-

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -1759,3 +1759,12 @@ upper left, upper right, lower right, lower left */
 	display: block;
 }
 
+/*--------------------------------------------Darkmode-------------------------------------*/
+
+/* Temporary fix until proper darkmode CSS is implemented */
+.sheet-darkmode .characterviewer label,
+html.dark th {
+    color: var(--color-foreground) !important;
+}
+
+


### PR DESCRIPTION


<!-- ATTENTION: This Pull Request template changed on 03/17/22. Please ensure that you are completing this template to the fullest extent possible. -->

# Submission Checklist
## Required

<!-- Check these off by adding an 'x' to each of these boxes. If you fail to meet all these criteria, your PR will be rejected. -->

- [ X ] The pull request title clearly contains the name of the sheet I am editing.
- [ X ] The pull request title clearly states the type of change I am submitting (New Sheet/New Feature/Bugfix/etc.).
- [ X ] The pull request makes changes to files in only one sub-folder.
- [ X ] The pull request does not contain changes to any json files in the translations folder (translation.json is permitted)

Eine grundlegende Maßnahme, um Label an Checkboxen im Charsheet und die Überschriften von Würfelergebnissen im Chat auch im Darkmode brauchbar lesen zu können. Kann und sollte im weiteren Verlauf ersetzt werden, wenn Dark Mode support vollständig implementiert wird, behebt aber vorerst die größten Probleme mit der Lesbarkeit im aktuellen Zustand ohne große Änderungen.