### PR TITLE
Sonderregeln Repräsentationen: Attribute modifizieren

### DIFF
--- a/Das_Schwarze_Auge_4-1/dev/css/style.css
+++ b/Das_Schwarze_Auge_4-1/dev/css/style.css
@@ -780,6 +780,14 @@ The solution: convert the <input>s to type="text" and make them look like normal
 	width: 13.25em !important;
 }
 
+.charsheet .talent-rep {
+	width: 4.5em !important;
+}
+
+.charsheet .talent-rep select {
+	width: 100%;
+}
+
 .charsheet .talent-eigenschaft {
 	width: 4.25em !important;
 }
@@ -819,6 +827,11 @@ The solution: convert the <input>s to type="text" and make them look like normal
 .charsheet button.abbr > span {
 	text-decoration-line: underline;
 	text-decoration-style: dotted;
+}
+
+/* spell spec & ZfW input */
+.charsheet .section-Zauberbogen .zauber input {
+	vertical-align: baseline;
 }
 
 /*---------------------------------------------Aktivierung---------------------------------------*/

--- a/Das_Schwarze_Auge_4-1/dev/html/roll templates/crp.html
+++ b/Das_Schwarze_Auge_4-1/dev/html/roll templates/crp.html
@@ -208,6 +208,11 @@
 			<td colspan="2" class="templates-warning"><span class="abbr" title="Der Wurf enthält zwei kritische Fehlschläge und wäre daher ohne den Vorteil Feste Matrix automatisch misslungen.">Feste Matrix hat Schlimmeres verhindert!</span></td>
 		</tr>
 		{{/rollBetween() computed::result -1 -1}}
+		{{#repmod}}
+		<tr>
+			<td colspan="2" class="templates-warning">Die verwendeten Attribute wurden durch die Repräsentation verändert.</td>
+		</tr>
+		{{/repmod}}
 	</table>
 </div>
 </rolltemplate>

--- a/Das_Schwarze_Auge_4-1/dev/html/sheet/footer.html
+++ b/Das_Schwarze_Auge_4-1/dev/html/sheet/footer.html
@@ -1,3 +1,3 @@
 <!-- sheet footer start -->
-	<b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="stat-immutable stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20240414"><input type="hidden" class="stat-immutable stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
+	<b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="stat-immutable stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20240421"><input type="hidden" class="stat-immutable stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
 <!-- sheet footer end -->

--- a/Das_Schwarze_Auge_4-1/dev/html/sheet/section_magie.html
+++ b/Das_Schwarze_Auge_4-1/dev/html/sheet/section_magie.html
@@ -24,17 +24,17 @@
 		<br>
 		<div class="section section-Zauberbogen" align="center">
 			<b>Repräsentation</b>
-			<select type="text" name="attr_subtag1" style="width: 12em;">
-				<option>---</option>
-				<option>gildenmagisch</option>
-				<option>elfisch</option>
-				<option>druidisch</option>
-				<option>satuarisch</option>
-				<option>geodisch</option>
-				<option>schelmisch</option>
-				<option>scharlatanisch</option>
-				<option>borbaradianisch</option>
-				<option>kristallomantisch</option>
+			<select type="text" name="attr_z_repraesentation" style="width: 12em;">
+				<option value="">---</option>
+				<option value="Mag">gildenmagisch</option>
+				<option value="Elf">elfisch</option>
+				<option value="Dru">druidisch</option>
+				<option value="Sat">satuarisch</option>
+				<option value="Geo">geodisch</option>
+				<option value="Sch">schelmisch</option>
+				<option value="Srl">scharlatanisch</option>
+				<option value="Bor">borbaradianisch</option>
+				<option value="Ach">kristallomantisch</option>
 			</select>
 			<br>
 			<b>Merkmale</b>

--- a/Das_Schwarze_Auge_4-1/dev/html/sheet/section_magie.html
+++ b/Das_Schwarze_Auge_4-1/dev/html/sheet/section_magie.html
@@ -127,7 +127,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Adamantium_rep">
+						<select type="text" name="attr_z_adamantium_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -156,7 +156,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Adlerauge_rep">
+						<select type="text" name="attr_z_adlerauge_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -185,7 +185,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Adlerschwinge_rep">
+						<select type="text" name="attr_z_adlerschwinge_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -214,7 +214,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aeolitus_rep">
+						<select type="text" name="attr_z_aeolitus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -243,7 +243,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aerofugo_rep">
+						<select type="text" name="attr_z_aerofugo_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -272,7 +272,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aerogelo_rep">
+						<select type="text" name="attr_z_aerogelo_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -301,7 +301,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aeropulvis_rep">
+						<select type="text" name="attr_z_aeropulvis_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -359,7 +359,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/GE + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Alpgestalt_rep">
+						<select type="text" name="attr_z_alpgestalt_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -388,7 +388,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN + <span class="abbr" title="Modifikator für die Analyseschwierigkeit">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Analys_rep">
+						<select type="text" name="attr_z_analys_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -417,7 +417,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_angste_rep">
+						<select type="text" name="attr_z_aengstelindern_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -446,7 +446,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Animatio_rep">
+						<select type="text" name="attr_z_animatio_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -475,7 +475,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Applicatus_rep">
+						<select type="text" name="attr_z_applicatus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -504,7 +504,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aquafaxius_rep">
+						<select type="text" name="attr_z_aquafaxius_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -533,7 +533,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aquaqueris_rep">
+						<select type="text" name="attr_z_aquaqueris_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -562,7 +562,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aquasphaero_rep">
+						<select type="text" name="attr_z_aquasphaero_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -591,7 +591,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Arachnea_rep">
+						<select type="text" name="attr_z_arachnea_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -620,7 +620,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Arcanovi_rep">
+						<select type="text" name="attr_z_arcanovi_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -649,7 +649,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Archofaxius_rep">
+						<select type="text" name="attr_z_archofaxius_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -678,7 +678,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Archosphaero_rep">
+						<select type="text" name="attr_z_archosphaero_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -707,7 +707,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Armatrutz_rep">
+						<select type="text" name="attr_z_armatrutz_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -736,7 +736,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Atemnot_rep">
+						<select type="text" name="attr_z_atemnot_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -805,7 +805,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/KO/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aufgeblasen_rep">
+						<select type="text" name="attr_z_aufgeblasen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -834,7 +834,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Auge_rep">
+						<select type="text" name="attr_z_augedeslimbus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -863,7 +863,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aureolus_rep">
+						<select type="text" name="attr_z_aureolus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -892,7 +892,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Auris_rep">
+						<select type="text" name="attr_z_aurisnasusoculus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -921,7 +921,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/GE/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Axxeleratus_rep">
+						<select type="text" name="attr_z_axxeleratus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -950,7 +950,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Heilung regeltechnischer Wunden">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Balsam_rep">
+						<select type="text" name="attr_z_balsam_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -979,7 +979,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_band_rep">
+						<select type="text" name="attr_z_bandundfessel_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -1008,7 +1008,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Bannbaladin_rep">
+						<select type="text" name="attr_z_bannbaladin_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -1037,7 +1037,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK + <span class="abbr" title="Modifikator für die Dauer des Schlafs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Barenruhe_rep">
+						<select type="text" name="attr_z_baerenruhe_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -1066,7 +1066,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Beherrschung_rep">
+						<select type="text" name="attr_z_beherrschungbrechen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -1124,7 +1124,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs und der beschworenen Wesenheit">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Beschworung_rep">
+						<select type="text" name="attr_z_beschwoerungvereiteln_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -1153,7 +1153,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Bewegung_rep">
+						<select type="text" name="attr_z_bewegungstoeren_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -1211,7 +1211,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Blendwerk_rep">
+						<select type="text" name="attr_z_blendwerk_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -1356,7 +1356,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/GE + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Blitz_rep">
+						<select type="text" name="attr_z_blitz_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -1385,7 +1385,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_boser_rep">
+						<select type="text" name="attr_z_boeserblick_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -1733,7 +1733,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_damonenbann_rep">
+						<select type="text" name="attr_z_daemonenbann_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -1849,7 +1849,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_dichter_rep">
+						<select type="text" name="attr_z_dichterunddenker_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -1878,7 +1878,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Dschinnenruf_rep">
+						<select type="text" name="attr_z_dschinnenruf_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -1907,7 +1907,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Dunkelheit_rep">
+						<select type="text" name="attr_z_dunkelheit_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -1994,7 +1994,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_eigenschaft_rep">
+						<select type="text" name="attr_z_eigenschaftwiederherstellen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2023,7 +2023,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_eigne_rep">
+						<select type="text" name="attr_z_eigneaengste_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2052,7 +2052,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_einfluss_rep">
+						<select type="text" name="attr_z_einflussbannen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2081,7 +2081,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_eins_rep">
+						<select type="text" name="attr_z_einsmitdernatur_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2139,7 +2139,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_eiseskalte_rep">
+						<select type="text" name="attr_z_eiseskaelte_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2168,7 +2168,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Eiswirbel_rep">
+						<select type="text" name="attr_z_eiswirbel_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2197,7 +2197,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Elementarbann_rep">
+						<select type="text" name="attr_z_elementarbann_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2226,7 +2226,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_elementarer_rep">
+						<select type="text" name="attr_z_elementarerdiener_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2313,7 +2313,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_erinnerung_rep">
+						<select type="text" name="attr_z_erinnerungverlassedich_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2429,7 +2429,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Fesselranken_rep">
+						<select type="text" name="attr_z_fesselranken_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2458,7 +2458,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Feuermaehne_rep">
+						<select type="text" name="attr_z_feuermaehne_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2487,7 +2487,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Feuersturm_rep">
+						<select type="text" name="attr_z_feuersturm_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2516,7 +2516,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Firnlauf_rep">
+						<select type="text" name="attr_z_firnlauf_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2545,7 +2545,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_flim_rep">
+						<select type="text" name="attr_z_flimflam_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2574,7 +2574,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_fluch_rep">
+						<select type="text" name="attr_z_fluchderpestilenz_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2661,7 +2661,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Frigifaxius_rep">
+						<select type="text" name="attr_z_frigifaxius_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2690,7 +2690,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Frigisphaero_rep">
+						<select type="text" name="attr_z_frigisphaero_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2835,7 +2835,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_gefass_rep">
+						<select type="text" name="attr_z_gefaessderjahre_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2893,7 +2893,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Austreibungsschwierigkeit des Geistes">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Geisterbann_rep">
+						<select type="text" name="attr_z_geisterbann_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2922,7 +2922,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Geistes">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Geisterruf_rep">
+						<select type="text" name="attr_z_geisterruf_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -2980,7 +2980,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Glacoflumen_rep">
+						<select type="text" name="attr_z_glacoflumen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3009,7 +3009,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Gletscherwand_rep">
+						<select type="text" name="attr_z_gletscherwand_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3038,7 +3038,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_granit_rep">
+						<select type="text" name="attr_z_granitundmarmor_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3154,7 +3154,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Halluzination_rep">
+						<select type="text" name="attr_z_halluzination_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3183,7 +3183,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Harmlose_rep">
+						<select type="text" name="attr_z_harmlosegestalt_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3212,7 +3212,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_hartes_rep">
+						<select type="text" name="attr_z_hartesschmelze_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3299,7 +3299,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_heilkraft_rep">
+						<select type="text" name="attr_z_heilkraftbannen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3328,7 +3328,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_hellsicht_rep">
+						<select type="text" name="attr_z_hellsichttrueben_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3357,7 +3357,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_herbeirufung_rep">
+						<select type="text" name="attr_z_herbeirufungvereiteln_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3386,7 +3386,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_herr_rep">
+						<select type="text" name="attr_z_herrueberdastierreich_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3415,7 +3415,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_herzschlag_rep">
+						<select type="text" name="attr_z_herzschlagruhe_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3473,7 +3473,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Hexenblick_rep">
+						<select type="text" name="attr_z_hexenblick_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3502,7 +3502,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Hexengalle_rep">
+						<select type="text" name="attr_z_hexengalle_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3531,7 +3531,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Hexenholz_rep">
+						<select type="text" name="attr_z_hexenholz_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3560,7 +3560,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Hexenknoten_rep">
+						<select type="text" name="attr_z_hexenknoten_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3589,7 +3589,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Hexenkrallen_rep">
+						<select type="text" name="attr_z_hexenkrallen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3618,7 +3618,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Hexenspeichel_rep">
+						<select type="text" name="attr_z_hexenspeichel_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3647,7 +3647,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="geistige Magieresistenz des Tieres">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_hilfreiche_rep">
+						<select type="text" name="attr_z_hilfreichetatze_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3676,7 +3676,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_hollenpein_rep">
+						<select type="text" name="attr_z_hoellenpein_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3705,7 +3705,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Holterdipolter_rep">
+						<select type="text" name="attr_z_holterdipolter_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3792,7 +3792,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Humofaxius_rep">
+						<select type="text" name="attr_z_humofaxius_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3821,7 +3821,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Humosphaero_rep">
+						<select type="text" name="attr_z_humosphaero_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3908,7 +3908,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Ignifugo_rep">
+						<select type="text" name="attr_z_ignifugo_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3937,7 +3937,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Ignimorpho_rep">
+						<select type="text" name="attr_z_ignimorpho_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -3966,7 +3966,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Igniplano_rep">
+						<select type="text" name="attr_z_igniplano_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4082,7 +4082,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_illusion_rep">
+						<select type="text" name="attr_z_illusionaufloesen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4314,7 +4314,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/IN + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_iribaars_rep">
+						<select type="text" name="attr_z_iribaarshand_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4401,7 +4401,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Katzenaugen_rep">
+						<select type="text" name="attr_z_katzenaugen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4430,7 +4430,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/CH + <span class="abbr" title="Modifikator für die Giftstufe">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_klarum_rep">
+						<select type="text" name="attr_z_klarumpurum_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4459,7 +4459,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Klickeradomms_rep">
+						<select type="text" name="attr_z_klickeradomms_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4488,7 +4488,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Koboldgeschenk_rep">
+						<select type="text" name="attr_z_koboldgeschenk_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4517,7 +4517,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Koboldovision_rep">
+						<select type="text" name="attr_z_koboldovision_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4546,7 +4546,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_komm_rep">
+						<select type="text" name="attr_z_kommkoboldkomm_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4575,7 +4575,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/IN</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_koerperlose_rep">
+						<select type="text" name="attr_z_koerperlosereise_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4604,7 +4604,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_krabbelnder_rep">
+						<select type="text" name="attr_z_krabbelnderschrecken_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4633,7 +4633,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KO/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_kraft_rep">
+						<select type="text" name="attr_z_kraftdeserzes_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4662,7 +4662,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_kraft_humus_rep">
+						<select type="text" name="attr_z_kraftdeshumus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4691,7 +4691,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_krahenruf_rep">
+						<select type="text" name="attr_z_kraehenruf_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4720,7 +4720,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_krotensprung_rep">
+						<select type="text" name="attr_z_kroetensprung_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4807,7 +4807,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_lach_rep">
+						<select type="text" name="attr_z_lachdichgesund_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4836,7 +4836,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Lachkrampf_rep">
+						<select type="text" name="attr_z_lachkrampf_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4865,7 +4865,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/GE/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_langer_rep">
+						<select type="text" name="attr_z_langerlulatsch_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -4894,7 +4894,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_last_rep">
+						<select type="text" name="attr_z_lastdesalters_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5126,7 +5126,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Leidensbund_rep">
+						<select type="text" name="attr_z_leidensbund_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5155,7 +5155,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_levthans_rep">
+						<select type="text" name="attr_z_levthansfeuer_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5184,7 +5184,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_limbus_rep">
+						<select type="text" name="attr_z_limbusversiegeln_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5242,7 +5242,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_lunge_rep">
+						<select type="text" name="attr_z_lungedesleviatan_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5271,7 +5271,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/IN</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_madas_rep">
+						<select type="text" name="attr_z_madasspiegel_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5300,7 +5300,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_magischer_rep">
+						<select type="text" name="attr_z_magischerraub_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5329,7 +5329,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Mahlstrom_rep">
+						<select type="text" name="attr_z_mahlstrom_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5358,7 +5358,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Malmkreis_rep">
+						<select type="text" name="attr_z_malmkreis_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5561,7 +5561,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_metamagie_rep">
+						<select type="text" name="attr_z_metamagieneutralisieren_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5590,7 +5590,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_metamorpho_felsenform_rep">
+						<select type="text" name="attr_z_metamorphofelsenform_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5619,7 +5619,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_metamorpho_rep">
+						<select type="text" name="attr_z_metamorphogletscherform_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5706,7 +5706,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF + <span class="abbr" title="höchste Magieresistenz plus Anzahl Betroffener">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_murks_rep">
+						<select type="text" name="attr_z_murksundpatz_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5735,7 +5735,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Gesamtrüstschutz des Opfers">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Nackedei_rep">
+						<select type="text" name="attr_z_nackedei_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5764,7 +5764,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Nebelleib_rep">
+						<select type="text" name="attr_z_nebelleib_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5909,7 +5909,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_objecto_rep">
+						<select type="text" name="attr_z_objectoobscuro_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5938,7 +5938,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Objectofixo_rep">
+						<select type="text" name="attr_z_objectofixo_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -5996,7 +5996,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_objekt_rep">
+						<select type="text" name="attr_z_objektentzaubern_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -6083,7 +6083,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Orcanofaxius_rep">
+						<select type="text" name="attr_z_orcanofaxius_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -6112,7 +6112,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Orcanosphaero_rep">
+						<select type="text" name="attr_z_orcanosphaero_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -6141,7 +6141,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Größe des dämonenverseuchten Gebiets">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Pandaemonium_rep">
+						<select type="text" name="attr_z_pandaemonium_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -6199,7 +6199,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Papperlapapp_rep">
+						<select type="text" name="attr_z_papperlapapp_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -6228,7 +6228,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_paralys_rep">
+						<select type="text" name="attr_z_paralysis_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -6344,7 +6344,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Entdeckungsschwierigkeit der Krankheit oder der Giftstufe des Giftes">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_pestilenz_rep">
+						<select type="text" name="attr_z_pestilenzerspueren_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -6837,7 +6837,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_ruhe_rep">
+						<select type="text" name="attr_z_ruhekoerper_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -6895,7 +6895,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Sanftmut_rep">
+						<select type="text" name="attr_z_sanftmut_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -6953,7 +6953,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_satuarias_rep">
+						<select type="text" name="attr_z_satuariasherrlichkeit_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -6982,7 +6982,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Schabernack_rep">
+						<select type="text" name="attr_z_schabernack_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7011,7 +7011,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_schadenszauber_rep">
+						<select type="text" name="attr_z_schadenszauberbannen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7040,7 +7040,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Schelmenkleister_rep">
+						<select type="text" name="attr_z_schelmenkleister_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7069,7 +7069,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Höchste Magieresistenz + Zahl der Betroffenen + Stärke des Stimmungsumschwungs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Schelmenlaune_rep">
+						<select type="text" name="attr_z_schelmenlaune_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7098,7 +7098,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Schelmenmaske_rep">
+						<select type="text" name="attr_z_schelmenmaske_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7127,7 +7127,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Schelmenrausch_rep">
+						<select type="text" name="attr_z_schelmenrausch_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7185,7 +7185,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_schleier_rep">
+						<select type="text" name="attr_z_schleierderunwissenheit_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7301,7 +7301,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_seelentier_rep">
+						<select type="text" name="attr_z_seelentiererkennen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7823,7 +7823,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die handwerkliche Qualität des unbelebten Golemids, das Grundmaterial, die elementare Reinheit des Ausgangsmaterials, der Größe des Golemids, der Eigenschaften des Golemids, die Anzahl weiterer Dienste, die besonderen Fähigkeiten des Golemids und die Talentwerte des Golemids">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_staub_rep">
+						<select type="text" name="attr_z_staubwandle_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7852,7 +7852,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Steinmauer_rep">
+						<select type="text" name="attr_z_steinmauer_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7881,7 +7881,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KK + <span class="abbr" title="Modifikator für die handwerkliche Qualität des unbelebten Golems, das Grundmaterial, die Affinität des Materials zum Erzdämonen, der Größe des Golems, der Eigenschaften des Golems, die Anzahl weiterer Dienste, die besonderen Fähigkeiten des Golems und die Talentwerte des Golems">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_stein_rep">
+						<select type="text" name="attr_z_steinwandle_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7939,7 +7939,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/IN</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Stimmen_des_Windes_rep">
+						<select type="text" name="attr_z_stimmendeswindes_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7968,7 +7968,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Sumpfstrudel_rep">
+						<select type="text" name="attr_z_sumpfstrudel_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7997,7 +7997,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_sumus_rep">
+						<select type="text" name="attr_z_sumuselixiere_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8084,7 +8084,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK + <span class="abbr" title="1 pro Kampfrunde">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_tempus_rep">
+						<select type="text" name="attr_z_tempusstasis_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8142,7 +8142,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Anzahl zu heilender regeltechnischer Wunden, der Stufe der Krankheit oder der halben Giftstufe">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_tiere_rep">
+						<select type="text" name="attr_z_tierebesprechen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8229,7 +8229,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_tlalucs_rep">
+						<select type="text" name="attr_z_tlalucsodem_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8258,7 +8258,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Untoten">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_totes_rep">
+						<select type="text" name="attr_z_toteshandle_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8374,7 +8374,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Traumgestalt_rep">
+						<select type="text" name="attr_z_traumgestalt_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8403,7 +8403,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Umbraporta_rep">
+						<select type="text" name="attr_z_umbraporta_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8432,7 +8432,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO + <span class="abbr" title="1 pro Tag Wirkungsdauer über den ersten hinaus">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_unberuhrt_rep">
+						<select type="text" name="attr_z_unberuehrt_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8519,7 +8519,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_unsichtbarer_rep">
+						<select type="text" name="attr_z_unsichtbarerjaeger_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8577,7 +8577,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_veranderung_rep">
+						<select type="text" name="attr_z_veraenderungaufheben_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8635,7 +8635,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_verstandigung_rep">
+						<select type="text" name="attr_z_verstaendigungstoeren_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8664,7 +8664,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_verwandlung_rep">
+						<select type="text" name="attr_z_verwandlungbeenden_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8838,7 +8838,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Wand_aus_Flammen_rep">
+						<select type="text" name="attr_z_wandausflammen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8867,7 +8867,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/IN</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_warmes_rep">
+						<select type="text" name="attr_z_warmesblut_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8896,7 +8896,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Warmes_gefriere_rep">
+						<select type="text" name="attr_z_warmesgefriere_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8954,7 +8954,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Wasserwall_rep">
+						<select type="text" name="attr_z_wasserwall_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8983,7 +8983,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_weiches_rep">
+						<select type="text" name="attr_z_weicheserstarre_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9041,7 +9041,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="1 pro Woche Wirkungsdauer">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_weisheit_rep">
+						<select type="text" name="attr_z_weisheitderbaeume_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9099,7 +9099,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_weisse_rep">
+						<select type="text" name="attr_z_weissemaehn_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9215,7 +9215,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Windbarriere_rep">
+						<select type="text" name="attr_z_windbarriere_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9244,7 +9244,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/IN</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Windgefluester_rep">
+						<select type="text" name="attr_z_windgefluester_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9273,7 +9273,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Windhose_rep">
+						<select type="text" name="attr_z_windhose_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9302,7 +9302,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KK + <span class="abbr" title="Modifikator für die vorherrschende Windstärke">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Windstille_rep">
+						<select type="text" name="attr_z_windstille_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9331,7 +9331,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Wipfellauf_rep">
+						<select type="text" name="attr_z_wipfellauf_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9418,7 +9418,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Zappenduster_rep">
+						<select type="text" name="attr_z_zappenduster_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9563,7 +9563,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Elementspezialisierung">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_zorn_rep">
+						<select type="text" name="attr_z_zornderelemente_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9592,7 +9592,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_zunge_rep">
+						<select type="text" name="attr_z_zungelaehmen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9621,7 +9621,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Zwingtanz_rep">
+						<select type="text" name="attr_z_zwingtanz_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>

--- a/Das_Schwarze_Auge_4-1/dev/html/sheet/section_magie.html
+++ b/Das_Schwarze_Auge_4-1/dev/html/sheet/section_magie.html
@@ -24,7 +24,7 @@
 		<br>
 		<div class="section section-Zauberbogen" align="center">
 			<b>Repräsentation</b>
-			<select type="text" name="attr_z_repraesentation" style="width: 12em;">
+			<select type="text" name="attr_z_erstrepraesentation" style="width: 12em;">
 				<option value="">---</option>
 				<option value="Mag">gildenmagisch</option>
 				<option value="Elf">elfisch</option>
@@ -35,6 +35,7 @@
 				<option value="Srl">scharlatanisch</option>
 				<option value="Bor">borbaradianisch</option>
 				<option value="Ach">kristallomantisch</option>
+				<option value="Kop">kophtanisch</option>
 			</select>
 			<br>
 			<b>Merkmale</b>
@@ -53,6 +54,7 @@
 				<div style="display:inline-block">
 					<div class="talent-cell talent-name talent-head">Zauber</div>
 					<div class="talent-cell talent-eigenschaften talent-head">Eigenschaften</div>
+					<div class="talent-cell talent-rep talent-head">Repräsentation</div>
 					<div class="talent-cell talent-spez talent-head">Spezialisierung</div>
 					<div class="talent-cell talent-taw talent-head">ZfW</div>
 					<div class="talent-cell talent-taw talent-head">Seite</div>
@@ -66,6 +68,21 @@
 						<button type="roll" name="roll_z_abvenenum" value="@{z_abvenenum_action}"> <span>Abvenenum Reine Speise</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF + <span class="abbr" title="Modifikator abhängig von Giftstufe, Krankheit und Genießbarkeit (frisch, verdorben)">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_abvenenum_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_abvenenum">
 					<input type="number" class="talent-taw" name="attr_ZfW_abvenenum" min="0" value="0">
 					<div class="talent-cell talent-taw">11</div>
@@ -80,6 +97,21 @@
 						<button type="roll" name="roll_z_accuratum" value="@{z_accuratum_action}"> <span>Accuratum Zaubernadel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Schwierigkeit der Schneiderarbeit">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_accuratum_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_accuratum">
 					<input type="number" class="talent-taw" name="attr_ZfW_accuratum" min="0" value="0">
 					<div class="talent-cell talent-taw">12</div>
@@ -94,6 +126,21 @@
 						<button type="roll" name="roll_z_adamantium" value="@{z_adamantium_action}"> <span>Adamantium Erzstruktur</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Adamantium_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Adamantium">
 					<input type="number" class="talent-taw" name="attr_ZfW_Adamantium" min="0" value="0">
 					<div class="talent-cell talent-taw">13</div>
@@ -108,6 +155,21 @@
 						<button type="roll" name="roll_z_adlerauge" value="@{z_adlerauge_action}"> <span>Adlerauge Luchsenohr</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Adlerauge_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Adlerauge">
 					<input type="number" class="talent-taw" name="attr_ZfW_Adlerauge" min="0" value="0">
 					<div class="talent-cell talent-taw">15</div>
@@ -122,6 +184,21 @@
 						<button type="roll" name="roll_z_adlerschwinge" value="@{z_adlerschwinge_action}"> <span>Adlerschwinge Wolfsgestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Adlerschwinge_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Adlerschwinge">
 					<input type="number" class="talent-taw" name="attr_ZfW_Adlerschwinge" min="0" value="0">
 					<div class="talent-cell talent-taw">16</div>
@@ -136,6 +213,21 @@
 						<button type="roll" name="roll_z_aeolitus" value="@{z_aeolitus_action}"> <span>Aeolitus Windgebraus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aeolitus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aeolitus">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aeolitus" min="0" value="0">
 					<div class="talent-cell talent-taw">18</div>
@@ -150,6 +242,21 @@
 						<button type="roll" name="roll_z_aerofugo" value="@{z_aerofugo_action}"> <span>Aerofugo Vakuum</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aerofugo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aerofugo">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aerofugo" min="0" value="0">
 					<div class="talent-cell talent-taw">19</div>
@@ -164,6 +271,21 @@
 						<button type="roll" name="roll_z_aerogelo" value="@{z_aerogelo_action}"> <span>Aerogelo Atemqual</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aerogelo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aerogelo">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aerogelo" min="0" value="0">
 					<div class="talent-cell talent-taw">20</div>
@@ -178,6 +300,21 @@
 						<button type="roll" name="roll_z_aeropulvis" value="@{z_aeropulvis_action}"> <span>Aeropulvis Sanfter Fall</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aeropulvis_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aeropulvis">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aeropulvis" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -192,6 +329,21 @@
 						<button type="roll" name="roll_z_dz_agrimothbann" value="@{z_dz_agrimothbann_action}"> <span>Agrimothbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Agrimothbann_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Agrimothbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_Agrimothbann" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -206,6 +358,21 @@
 						<button type="roll" name="roll_z_alpgestalt" value="@{z_alpgestalt_action}"> <span>Alpgestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/GE + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Alpgestalt_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Alpgestalt">
 					<input type="number" class="talent-taw" name="attr_ZfW_Alpgestalt" min="0" value="0">
 					<div class="talent-cell talent-taw">21</div>
@@ -220,6 +387,21 @@
 						<button type="roll" name="roll_z_analys" value="@{z_analys_action}"> <span>Analys Arcanstruktur</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN + <span class="abbr" title="Modifikator für die Analyseschwierigkeit">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Analys_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Analys">
 					<input type="number" class="talent-taw" name="attr_ZfW_Analys" min="0" value="0">
 					<div class="talent-cell talent-taw">22</div>
@@ -234,6 +416,21 @@
 						<button type="roll" name="roll_z_aengstelindern" value="@{z_aengstelindern_action}"> <span>Ängste lindern</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_angste_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_angste">
 					<input type="number" class="talent-taw" name="attr_ZfW_angste" min="0" value="0">
 					<div class="talent-cell talent-taw">23</div>
@@ -248,6 +445,21 @@
 						<button type="roll" name="roll_z_animatio" value="@{z_animatio_action}"> <span>Animatio Stummer Diener</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Animato_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Animato">
 					<input type="number" class="talent-taw" name="attr_ZfW_Animato" min="0" value="0">
 					<div class="talent-cell talent-taw">24</div>
@@ -262,6 +474,21 @@
 						<button type="roll" name="roll_z_applicatus" value="@{z_applicatus_action}"> <span>Applicatus Zauberspeicher</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Applicatus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Applicatus">
 					<input type="number" class="talent-taw" name="attr_ZfW_Applicatus" min="0" value="0">
 					<div class="talent-cell talent-taw">25</div>
@@ -276,6 +503,21 @@
 						<button type="roll" name="roll_z_aquafaxius" value="@{z_aquafaxius_action}"> <span>Aquafaxius</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aquafaxius_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aquafaxius">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aquafaxius" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -290,6 +532,21 @@
 						<button type="roll" name="roll_z_aquaqueris" value="@{z_aquaqueris_action}"> <span>Aquaqueris Wasserfluch</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aquaqueris_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aquaqueris">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aquaqueris" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -304,6 +561,21 @@
 						<button type="roll" name="roll_z_aquasphaero" value="@{z_aquasphaero_action}"> <span>Aquasphaero</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aquasphaero_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aquasphaero">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aquasphaero" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -318,6 +590,21 @@
 						<button type="roll" name="roll_z_arachnea" value="@{z_arachnea_action}"> <span>Arachnea Krabbeltier</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Arachnea_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Arachnea">
 					<input type="number" class="talent-taw" name="attr_ZfW_Arachnea" min="0" value="0">
 					<div class="talent-cell talent-taw">26</div>
@@ -332,6 +619,21 @@
 						<button type="roll" name="roll_z_arcanovi" value="@{z_arcanovi_action}"> <span>Arcanovi Artefakt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Arcanovi_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Arcanovi">
 					<input type="number" class="talent-taw" name="attr_ZfW_Arcanovi" min="0" value="0">
 					<div class="talent-cell talent-taw">27</div>
@@ -346,6 +648,21 @@
 						<button type="roll" name="roll_z_archofaxius" value="@{z_archofaxius_action}"> <span>Archofaxius</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Archofaxius_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Archofaxius">
 					<input type="number" class="talent-taw" name="attr_ZfW_Archofaxius" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -360,6 +677,21 @@
 						<button type="roll" name="roll_z_archosphaero" value="@{z_archosphaero_action}"> <span>Archosphaero</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Archosphaero_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Archosphaero">
 					<input type="number" class="talent-taw" name="attr_ZfW_Archosphaero" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -374,6 +706,21 @@
 						<button type="roll" name="roll_z_armatrutz" value="@{z_armatrutz_action}"> <span>Armatrutz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Armatrutz_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Armatrutz">
 					<input type="number" class="talent-taw" name="attr_ZfW_Armatrutz" min="0" value="0">
 					<div class="talent-cell talent-taw">28</div>
@@ -388,6 +735,21 @@
 						<button type="roll" name="roll_z_atemnot" value="@{z_atemnot_action}"> <span>Atemnot</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Atemnot_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Atemnot">
 					<input type="number" class="talent-taw" name="attr_ZfW_Atemnot" min="0" value="0">
 					<div class="talent-cell talent-taw">29</div>
@@ -427,6 +789,21 @@
 						<button type="roll" name="roll_z_aufgeblasen" value="@{z_aufgeblasen_action}"> <span>Aufgeblasen Abgehoben</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/KO/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aufgeblasen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aufgeblasen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aufgeblasen" min="0" value="0">
 					<div class="talent-cell talent-taw">31</div>
@@ -441,6 +818,21 @@
 						<button type="roll" name="roll_z_augedeslimbus" value="@{z_augedeslimbus_action}"> <span>Auge des Limbus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Auge_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Auge">
 					<input type="number" class="talent-taw" name="attr_ZfW_Auge" min="0" value="0">
 					<div class="talent-cell talent-taw">32</div>
@@ -455,6 +847,21 @@
 						<button type="roll" name="roll_z_aureolus" value="@{z_aureolus_action}"> <span>Aureolus Güldenglanz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aureolus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aureolus">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aureolus" min="0" value="0">
 					<div class="talent-cell talent-taw">33</div>
@@ -469,6 +876,21 @@
 						<button type="roll" name="roll_z_aurisnasusoculus" value="@{z_aurisnasusoculus_action}"> <span>Auris Nasus Oculus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Auris_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Auris">
 					<input type="number" class="talent-taw" name="attr_ZfW_Auris" min="0" value="0">
 					<div class="talent-cell talent-taw">35</div>
@@ -483,6 +905,21 @@
 						<button type="roll" name="roll_z_axxeleratus" value="@{z_axxeleratus_action}"> <span>Axxeleratus Blitzgeschwind</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Axxeleratus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Axxeleratus">
 					<input type="number" class="talent-taw" name="attr_ZfW_Axxeleratus" min="0" value="0">
 					<div class="talent-cell talent-taw">36</div>
@@ -497,6 +934,21 @@
 						<button type="roll" name="roll_z_balsam" value="@{z_balsam_action}"> <span>Balsam Salabunde</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Heilung regeltechnischer Wunden">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Balsam_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Balsam">
 					<input type="number" class="talent-taw" name="attr_ZfW_Balsam" min="0" value="0">
 					<div class="talent-cell talent-taw">37</div>
@@ -511,6 +963,21 @@
 						<button type="roll" name="roll_z_bandundfessel" value="@{z_bandundfessel_action}"> <span>Band und Fessel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_band_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_band">
 					<input type="number" class="talent-taw" name="attr_ZfW_band" min="0" value="0">
 					<div class="talent-cell talent-taw">38</div>
@@ -525,6 +992,21 @@
 						<button type="roll" name="roll_z_bannbaladin" value="@{z_bannbaladin_action}"> <span>Bannbaladin</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Bannbaladin_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Bannbaladin">
 					<input type="number" class="talent-taw" name="attr_ZfW_Bannbaladin" min="0" value="0">
 					<div class="talent-cell talent-taw">39</div>
@@ -539,6 +1021,21 @@
 						<button type="roll" name="roll_z_baerenruhe" value="@{z_baerenruhe_action}"> <span>Bärenruhe Winterschlaf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK + <span class="abbr" title="Modifikator für die Dauer des Schlafs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Barenruhe_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Barenruhe">
 					<input type="number" class="talent-taw" name="attr_ZfW_Barenruhe" min="0" value="0">
 					<div class="talent-cell talent-taw">40</div>
@@ -553,6 +1050,21 @@
 						<button type="roll" name="roll_z_beherrschungbrechen" value="@{z_beherrschungbrechen_action}"> <span>Beherrschung brechen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Beherrschung_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Beherrschung">
 					<input type="number" class="talent-taw" name="attr_ZfW_Beherrschung" min="0" value="0">
 					<div class="talent-cell talent-taw">41</div>
@@ -567,6 +1079,21 @@
 						<button type="roll" name="roll_z_dz_belzhorashbann" value="@{z_dz_belzhorashbann_action}"> <span>Belzhorashbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Belzhorashbann_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Belzhorashbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_Belzhorashbann" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -581,6 +1108,21 @@
 						<button type="roll" name="roll_z_beschwoerungvereiteln" value="@{z_beschwoerungvereiteln_action}"> <span>Beschwörung vereiteln</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs und der beschworenen Wesenheit">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Beschworung_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Beschworung">
 					<input type="number" class="talent-taw" name="attr_ZfW_Beschworung" min="0" value="0">
 					<div class="talent-cell talent-taw">42</div>
@@ -595,6 +1137,21 @@
 						<button type="roll" name="roll_z_bewegungstoeren" value="@{z_bewegungstoeren_action}"> <span>Bewegung stören</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Bewegung_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Bewegung">
 					<input type="number" class="talent-taw" name="attr_ZfW_Bewegung" min="0" value="0">
 					<div class="talent-cell talent-taw">43</div>
@@ -609,6 +1166,21 @@
 						<button type="roll" name="roll_z_dz_bienenschwarm" value="@{z_dz_bienenschwarm_action}"> <span>Bienenschwarm</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Bienenschwarm_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Bienenschwarm">
 					<input type="number" class="talent-taw" name="attr_ZfW_Bienenschwarm" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -623,6 +1195,21 @@
 						<button type="roll" name="roll_z_blendwerk" value="@{z_blendwerk_action}"> <span>Blendwerk</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Blendwerk_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Blendwerk">
 					<input type="number" class="talent-taw" name="attr_ZfW_Blendwerk" min="0" value="0">
 					<div class="talent-cell talent-taw">44</div>
@@ -637,6 +1224,21 @@
 						<button type="roll" name="roll_z_blickaufswesen" value="@{z_blickaufswesen_action}"> <span>Blick aufs Wesen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_blickaufswesen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_blickaufswesen">
 					<input type="number" class="talent-taw" name="attr_ZfW_blickaufswesen" min="0" value="0">
 					<div class="talent-cell talent-taw">45</div>
@@ -651,6 +1253,21 @@
 						<button type="roll" name="roll_z_blickdurchfremdeaugen" value="@{z_blickdurchfremdeaugen_action}"> <span>Blick durch fremde Augen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_blickdurchfremdeaugen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_blickdurchfremdeaugen">
 					<input type="number" class="talent-taw" name="attr_ZfW_blickdurchfremdeaugen" min="0" value="0">
 					<div class="talent-cell talent-taw">46</div>
@@ -665,6 +1282,21 @@
 						<button type="roll" name="roll_z_blickindiegedanken" value="@{z_blickindiegedanken_action}"> <span>Blick in die Gedanken</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_blickindiegedanken_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_blickindiegedanken">
 					<input type="number" class="talent-taw" name="attr_ZfW_blickindiegedanken" min="0" value="0">
 					<div class="talent-cell talent-taw">47</div>
@@ -679,6 +1311,21 @@
 						<button type="roll" name="roll_z_blickindievergangenheit" value="@{z_blickindievergangenheit_action}"> <span>Blick in die Vergangenheit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN + <span class="abbr" title="Modifikator für die Zeitspanne, die zurückgeblickt werden soll">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_blickindievergangenheit_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_blickindievergangenheit">
 					<input type="number" class="talent-taw" name="attr_ZfW_blickindievergangenheit" min="0" value="0">
 					<div class="talent-cell talent-taw">48</div>
@@ -693,6 +1340,21 @@
 						<button type="roll" name="roll_z_blitz" value="@{z_blitz_action}"> <span>Blitz dich find</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/GE + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Blitz_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Blitz">
 					<input type="number" class="talent-taw" name="attr_ZfW_Blitz" min="0" value="0">
 					<div class="talent-cell talent-taw">49</div>
@@ -707,6 +1369,21 @@
 						<button type="roll" name="roll_z_boeserblick" value="@{z_boeserblick_action}"> <span>Böser Blick</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_boser_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_boser">
 					<input type="number" class="talent-taw" name="attr_ZfW_boser" min="0" value="0">
 					<div class="talent-cell talent-taw">50</div>
@@ -721,6 +1398,21 @@
 						<button type="roll" name="roll_z_brenne" value="@{z_brenne_action}"> <span>Brenne, toter Stoff!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_brenne_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_brenne">
 					<input type="number" class="talent-taw" name="attr_ZfW_brenne" min="0" value="0">
 					<div class="talent-cell talent-taw">51</div>
@@ -735,6 +1427,21 @@
 						<button type="roll" name="roll_z_caldofrigo" value="@{z_caldofrigo_action}"> <span>Caldofrigo Heiß und Kalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_caldofrigo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_caldofrigo">
 					<input type="number" class="talent-taw" name="attr_ZfW_caldofrigo" min="0" value="0">
 					<div class="talent-cell talent-taw">52</div>
@@ -749,6 +1456,21 @@
 						<button type="roll" name="roll_z_chamaelioni" value="@{z_chamaelioni_action}"> <span>Chamaelioni Mimikry</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_chamaelioni_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_chamaelioni">
 					<input type="number" class="talent-taw" name="attr_ZfW_chamaelioni" min="0" value="0">
 					<div class="talent-cell talent-taw">54</div>
@@ -763,6 +1485,21 @@
 						<button type="roll" name="roll_z_chimaeroform" value="@{z_chimaeroform_action}"> <span>Chimaeroform Hybridgestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für den Verwandtschaftsgrad der Wesen, den Größenunterschied zwischen den Wesen, weiteren speziellen Fähigkeiten und den Umständen">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_chimaeroform_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_chimaeroform">
 					<input type="number" class="talent-taw" name="attr_ZfW_chimaeroform" min="0" value="0">
 					<div class="talent-cell talent-taw">55</div>
@@ -777,6 +1514,21 @@
 						<button type="roll" name="roll_z_chronoklassis" value="@{z_chronoklassis_action}"> <span>Chronoklassis Urfossil</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für den Zeitabstand, die Genauigkeit des Wissens über die Zeit, des Ortes und der Entfernung zum Ort">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_chronoklassis_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_chronoklassis">
 					<input type="number" class="talent-taw" name="attr_ZfW_chronoklassis" min="0" value="0">
 					<div class="talent-cell talent-taw">56</div>
@@ -791,6 +1543,21 @@
 						<button type="roll" name="roll_z_chrononautos" value="@{z_chrononautos_action}"> <span>Chrononautos Zeitenfahrt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für den Zeitabstand, den Transport von Ausrüstung und den Geburtszeitpunkten der Reisenden">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_chrononautos_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_chrononautos">
 					<input type="number" class="talent-taw" name="attr_ZfW_chrononautos" min="0" value="0">
 					<div class="talent-cell talent-taw">57</div>
@@ -805,6 +1572,21 @@
 						<button type="roll" name="roll_z_claudibus" value="@{z_claudibus_action}"> <span>Claudibus Clavistibor</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_claudibus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_claudibus">
 					<input type="number" class="talent-taw" name="attr_ZfW_claudibus" min="0" value="0">
 					<div class="talent-cell talent-taw">58</div>
@@ -819,6 +1601,21 @@
 						<button type="roll" name="roll_z_corpofesso" value="@{z_corpofesso_action}"> <span>Corpofesso Gliederschmerz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KO/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_corpofesso_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_corpofesso">
 					<input type="number" class="talent-taw" name="attr_ZfW_corpofesso" min="0" value="0">
 					<div class="talent-cell talent-taw">59</div>
@@ -833,6 +1630,21 @@
 						<button type="roll" name="roll_z_corpofrigo" value="@{z_corpofrigo_action}"> <span>Corpofrigo Kälteschock</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/GE/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_corpofrigo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_corpofrigo">
 					<input type="number" class="talent-taw" name="attr_ZfW_corpofrigo" min="0" value="0">
 					<div class="talent-cell talent-taw">60</div>
@@ -847,6 +1659,21 @@
 						<button type="roll" name="roll_z_cryptographo" value="@{z_cryptographo_action}"> <span>Cryptographo Zauberschrift</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_cryptographo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_cryptographo">
 					<input type="number" class="talent-taw" name="attr_ZfW_cryptographo" min="0" value="0">
 					<div class="talent-cell talent-taw">61</div>
@@ -861,6 +1688,21 @@
 						<button type="roll" name="roll_z_custodosigil" value="@{z_custodosigil_action}"> <span>Custodosigil Diebesbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_custodosigil_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_custodosigil">
 					<input type="number" class="talent-taw" name="attr_ZfW_custodosigil" min="0" value="0">
 					<div class="talent-cell talent-taw">62</div>
@@ -875,6 +1717,21 @@
 						<button type="roll" name="roll_z_daemonenbann" value="@{z_daemonenbann_action}"> <span>Dämonenbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_damonenbann_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_damonenbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_damonenbann" min="0" value="0">
 					<div class="talent-cell talent-taw">63</div>
@@ -889,6 +1746,21 @@
 						<button type="roll" name="roll_z_delicioso" value="@{z_delicioso_action}"> <span>Delicioso Gaumenschmaus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_delicioso_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_delicioso">
 					<input type="number" class="talent-taw" name="attr_ZfW_delicioso" min="0" value="0">
 					<div class="talent-cell talent-taw">64</div>
@@ -903,6 +1775,21 @@
 						<button type="roll" name="roll_z_desintegratus" value="@{z_desintegratus_action}"> <span>Desintegratus Pulverstaub</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_desintegratus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_desintegratus">
 					<input type="number" class="talent-taw" name="attr_ZfW_desintegratus" min="0" value="0">
 					<div class="talent-cell talent-taw">65</div>
@@ -917,6 +1804,21 @@
 						<button type="roll" name="roll_z_destructibo" value="@{z_destructibo_action}"> <span>Destructibo Arcanitas</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF + <span class="abbr" title="Modifikator für die Einstimmungszeit und Beschaffenheit des Objekts">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_destructibo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_destructibo">
 					<input type="number" class="talent-taw" name="attr_ZfW_destructibo" min="0" value="0">
 					<div class="talent-cell talent-taw">66</div>
@@ -931,6 +1833,21 @@
 						<button type="roll" name="roll_z_dichterunddenker" value="@{z_dichterunddenker_action}"> <span>Dichter und Denker</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dichter_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dichter">
 					<input type="number" class="talent-taw" name="attr_ZfW_dichter" min="0" value="0">
 					<div class="talent-cell talent-taw">67</div>
@@ -945,6 +1862,21 @@
 						<button type="roll" name="roll_z_dschinnenruf" value="@{z_dschinnenruf_action}"> <span>Dschinnenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Dschinnenruf_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Dschinnenruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Dschinnenruf" min="0" value="0">
 					<div class="talent-cell talent-taw">68</div>
@@ -959,6 +1891,21 @@
 						<button type="roll" name="roll_z_dunkelheit" value="@{z_dunkelheit_action}"> <span>Dunkelheit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Dunkelheit_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Dunkelheit">
 					<input type="number" class="talent-taw" name="attr_ZfW_Dunkelheit" min="0" value="0">
 					<div class="talent-cell talent-taw">69</div>
@@ -973,6 +1920,21 @@
 						<button type="roll" name="roll_z_duplicatus" value="@{z_duplicatus_action}"> <span>Duplicatus Doppelbild</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/GE + <span class="abbr" title="2 pro zusätzlichem Doppelgänger">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_duplicatus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_duplicatus">
 					<input type="number" class="talent-taw" name="attr_ZfW_duplicatus" min="0" value="0">
 					<div class="talent-cell talent-taw">70</div>
@@ -987,6 +1949,21 @@
 						<button type="roll" name="roll_z_ecliptifactus" value="@{z_ecliptifactus_action}"> <span>Ecliptifactus Schattenkraft</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_ecliptifactus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ecliptifactus">
 					<input type="number" class="talent-taw" name="attr_ZfW_ecliptifactus" min="0" value="0">
 					<div class="talent-cell talent-taw">71</div>
@@ -1001,6 +1978,21 @@
 						<button type="roll" name="roll_z_eigenschaftwiederherstellen" value="@{z_eigenschaftwiederherstellen_action}"> <span>Eigenschaft wiederherstellen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_eigenschaft_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eigenschaft">
 					<input type="number" class="talent-taw" name="attr_ZfW_eigenschaft" min="0" value="0">
 					<div class="talent-cell talent-taw">73</div>
@@ -1015,6 +2007,21 @@
 						<button type="roll" name="roll_z_eigneaengste" value="@{z_eigneaengste_action}"> <span>Eigne Ängste quälen dich!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_eigne_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eigne">
 					<input type="number" class="talent-taw" name="attr_ZfW_eigne" min="0" value="0">
 					<div class="talent-cell talent-taw">74</div>
@@ -1029,6 +2036,21 @@
 						<button type="roll" name="roll_z_einflussbannen" value="@{z_einflussbannen_action}"> <span>Einfluss bannen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_einfluss_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_einfluss">
 					<input type="number" class="talent-taw" name="attr_ZfW_einfluss" min="0" value="0">
 					<div class="talent-cell talent-taw">75</div>
@@ -1043,6 +2065,21 @@
 						<button type="roll" name="roll_z_einsmitdernatur" value="@{z_einsmitdernatur_action}"> <span>Eins mit der Natur</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_eins_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eins">
 					<input type="number" class="talent-taw" name="attr_ZfW_eins" min="0" value="0">
 					<div class="talent-cell talent-taw">76</div>
@@ -1057,6 +2094,21 @@
 						<button type="roll" name="roll_z_eisenrost" value="@{z_eisenrost_action}"> <span>Eisenrost und Patina</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_eisenrost_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eisenrost">
 					<input type="number" class="talent-taw" name="attr_ZfW_eisenrost" min="0" value="0">
 					<div class="talent-cell talent-taw">77</div>
@@ -1071,6 +2123,21 @@
 						<button type="roll" name="roll_z_eiseskaelte" value="@{z_eiseskaelte_action}"> <span>Eiseskälte Kämpferherz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_eiseskalte_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eiseskalte">
 					<input type="number" class="talent-taw" name="attr_ZfW_eiseskalte" min="0" value="0">
 					<div class="talent-cell talent-taw">78</div>
@@ -1085,6 +2152,21 @@
 						<button type="roll" name="roll_z_eiswirbel" value="@{z_eiswirbel_action}"> <span>Eiswirbel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Eiswirbel_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Eiswirbel">
 					<input type="number" class="talent-taw" name="attr_ZfW_Eiswirbel" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -1099,6 +2181,21 @@
 						<button type="roll" name="roll_z_elementarbann" value="@{z_elementarbann_action}"> <span>Elementarbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Elementarbann_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Elementarbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_Elementarbann" min="0" value="0">
 					<div class="talent-cell talent-taw">79</div>
@@ -1113,6 +2210,21 @@
 						<button type="roll" name="roll_z_elementarerdiener" value="@{z_elementarerdiener_action}"> <span>Elementarer Diener</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_elementarer_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_elementarer">
 					<input type="number" class="talent-taw" name="attr_ZfW_elementarer" min="0" value="0">
 					<div class="talent-cell talent-taw">80</div>
@@ -1127,6 +2239,21 @@
 						<button type="roll" name="roll_z_elfenstimme" value="@{z_elfenstimme_action}"> <span>Elfenstimme Flötenton</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_elfenstimme_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_elfenstimme">
 					<input type="number" class="talent-taw" name="attr_ZfW_elfenstimme" min="0" value="0">
 					<div class="talent-cell talent-taw">81</div>
@@ -1141,6 +2268,21 @@
 						<button type="roll" name="roll_z_dz_entfesselungdesgetiers" value="@{z_dz_entfesselungdesgetiers_action}"> <span>Entfesselung des Getiers</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Entfesselung_des_Getiers_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Entfesselung_des_Getiers">
 					<input type="number" class="talent-taw" name="attr_ZfW_Entfesselung_des_Getiers" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -1155,6 +2297,21 @@
 						<button type="roll" name="roll_z_erinnerungverlassedich" value="@{z_erinnerungverlassedich_action}"> <span>Erinnerung verlasse dich!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_erinnerung_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_erinnerung">
 					<input type="number" class="talent-taw" name="attr_ZfW_erinnerung" min="0" value="0">
 					<div class="talent-cell talent-taw">82</div>
@@ -1169,6 +2326,21 @@
 						<button type="roll" name="roll_z_exposami" value="@{z_exposami_action}"> <span>Exposami Lebenskraft</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_exposami_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_exposami">
 					<input type="number" class="talent-taw" name="attr_ZfW_exposami" min="0" value="0">
 					<div class="talent-cell talent-taw">83</div>
@@ -1183,6 +2355,21 @@
 						<button type="roll" name="roll_z_falkenauge" value="@{z_falkenauge_action}"> <span>Falkenauge Meisterschuss</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_falkenauge_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_falkenauge">
 					<input type="number" class="talent-taw" name="attr_ZfW_falkenauge" min="0" value="0">
 					<div class="talent-cell talent-taw">84</div>
@@ -1197,6 +2384,21 @@
 						<button type="roll" name="roll_z_favilludo" value="@{z_favilludo_action}"> <span>Favilludo Funkentanz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_favilludo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_favilludo">
 					<input type="number" class="talent-taw" name="attr_ZfW_favilludo" min="0" value="0">
 					<div class="talent-cell talent-taw">85</div>
@@ -1211,6 +2413,21 @@
 						<button type="roll" name="roll_z_fesselranken" value="@{z_fesselranken_action}"> <span>Fesselranken</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Fesselranken_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Fesselranken">
 					<input type="number" class="talent-taw" name="attr_ZfW_Fesselranken" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -1225,6 +2442,21 @@
 						<button type="roll" name="roll_z_feuermaehne" value="@{z_feuermaehne_action}"> <span>Feuermähne Flammenhuf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Feuermaehne_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Feuermaehne">
 					<input type="number" class="talent-taw" name="attr_ZfW_Feuermaehne" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -1239,6 +2471,21 @@
 						<button type="roll" name="roll_z_feuersturm" value="@{z_feuersturm_action}"> <span>Feuersturm</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Feuersturm_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Feuersturm">
 					<input type="number" class="talent-taw" name="attr_ZfW_Feuersturm" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -1253,6 +2500,21 @@
 						<button type="roll" name="roll_z_firnlauf" value="@{z_firnlauf_action}"> <span>Firnlauf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Firnlauf_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Firnlauf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Firnlauf" min="0" value="0">
 					<div class="talent-cell talent-taw">86</div>
@@ -1267,6 +2529,21 @@
 						<button type="roll" name="roll_z_flimflam" value="@{z_flimflam_action}"> <span>Flim Flam Funkel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_flim_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_flim">
 					<input type="number" class="talent-taw" name="attr_ZfW_flim" min="0" value="0">
 					<div class="talent-cell talent-taw">87</div>
@@ -1281,6 +2558,21 @@
 						<button type="roll" name="roll_z_fluchderpestilenz" value="@{z_fluchderpestilenz_action}"> <span>Fluch der Pestilenz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_fluch_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_fluch">
 					<input type="number" class="talent-taw" name="attr_ZfW_fluch" min="0" value="0">
 					<div class="talent-cell talent-taw">88</div>
@@ -1295,6 +2587,21 @@
 						<button type="roll" name="roll_z_foramen" value="@{z_foramen_action}"> <span>Foramen Foraminor</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF + <span class="abbr" title="Modifikator für die Komplexität des Schlosses">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_foramen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_foramen">
 					<input type="number" class="talent-taw" name="attr_ZfW_foramen" min="0" value="0">
 					<div class="talent-cell talent-taw">89</div>
@@ -1309,6 +2616,21 @@
 						<button type="roll" name="roll_z_fortifex" value="@{z_fortifex_action}"> <span>Fortifex Arkane Wand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_fortifex_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_fortifex">
 					<input type="number" class="talent-taw" name="attr_ZfW_fortifex" min="0" value="0">
 					<div class="talent-cell talent-taw">90</div>
@@ -1323,6 +2645,21 @@
 						<button type="roll" name="roll_z_frigifaxius" value="@{z_frigifaxius_action}"> <span>Frigifaxius</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Frigifaxius_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Frigifaxius">
 					<input type="number" class="talent-taw" name="attr_ZfW_Frigifaxius" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -1337,6 +2674,21 @@
 						<button type="roll" name="roll_z_frigisphaero" value="@{z_frigisphaero_action}"> <span>Frigisphaero</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Frigisphaero_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Frigisphaero">
 					<input type="number" class="talent-taw" name="attr_ZfW_Frigisphaero" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -1351,6 +2703,21 @@
 						<button type="roll" name="roll_z_fulminictus" value="@{z_fulminictus_action}"> <span>Fulminictus Donnerkeil</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_fulminictus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_fulminictus">
 					<input type="number" class="talent-taw" name="attr_ZfW_fulminictus" min="0" value="0">
 					<div class="talent-cell talent-taw">91</div>
@@ -1365,6 +2732,21 @@
 						<button type="roll" name="roll_z_gardianum" value="@{z_gardianum_action}"> <span>Gardianum Zauberschild</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_gardianum_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_gardianum">
 					<input type="number" class="talent-taw" name="attr_ZfW_gardianum" min="0" value="0">
 					<div class="talent-cell talent-taw">92</div>
@@ -1379,6 +2761,21 @@
 						<button type="roll" name="roll_z_dz_gebieterdertiefe" value="@{z_dz_gebieterdertiefe_action}"> <span>Gebieter der Tiefe</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Gebieter_der_Tiefe_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Gebieter_der_Tiefe">
 					<input type="number" class="talent-taw" name="attr_ZfW_Gebieter_der_Tiefe" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -1393,6 +2790,21 @@
 						<button type="roll" name="roll_z_gedankenbilder" value="@{z_gedankenbilder_action}"> <span>Gedankenbilder Elfenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_gedankenbilder_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_gedankenbilder">
 					<input type="number" class="talent-taw" name="attr_ZfW_gedankenbilder" min="0" value="0">
 					<div class="talent-cell talent-taw">94</div>
@@ -1407,6 +2819,21 @@
 						<button type="roll" name="roll_z_gefaessderjahre" value="@{z_gefaessderjahre_action}"> <span>Gefäß der Jahre</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_gefass_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_gefass">
 					<input type="number" class="talent-taw" name="attr_ZfW_gefass" min="0" value="0">
 					<div class="talent-cell talent-taw">95</div>
@@ -1421,6 +2848,21 @@
 						<button type="roll" name="roll_z_gefunden" value="@{z_gefunden_action}"> <span>Gefunden!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/GE + <span class="abbr" title="Modifikator für den Abstand, die Größe, der Vertrautheit und weiteren Besonderheiten">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_gefunden_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_gefunden">
 					<input type="number" class="talent-taw" name="attr_ZfW_gefunden" min="0" value="0">
 					<div class="talent-cell talent-taw">96</div>
@@ -1435,6 +2877,21 @@
 						<button type="roll" name="roll_z_geisterbann" value="@{z_geisterbann_action}"> <span>Geisterbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Austreibungsschwierigkeit des Geistes">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Geisterbann_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Geisterbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_Geisterbann" min="0" value="0">
 					<div class="talent-cell talent-taw">97</div>
@@ -1449,6 +2906,21 @@
 						<button type="roll" name="roll_z_geisterruf" value="@{z_geisterruf_action}"> <span>Geisterruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Geistes">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Geisterruf_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Geisterruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Geisterruf" min="0" value="0">
 					<div class="talent-cell talent-taw">98</div>
@@ -1463,6 +2935,21 @@
 						<button type="roll" name="roll_z_dz_geschossderniederhoellen" value="@{z_dz_geschossderniederhoellen_action}"> <span>Geschoss der Niederhöllen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Geschoss_der_Niederhoellen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Geschoss_der_Niederhoellen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Geschoss_der_Niederhoellen" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -1477,6 +2964,21 @@
 						<button type="roll" name="roll_z_glacoflumen" value="@{z_glacoflumen_action}"> <span>Glacoflumen Fluss aus Eis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Glacoflumen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Glacoflumen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Glacoflumen" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -1491,6 +2993,21 @@
 						<button type="roll" name="roll_z_gletscherwand" value="@{z_gletscherwand_action}"> <span>Gletscherwand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Gletscherwand_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Gletscherwand">
 					<input type="number" class="talent-taw" name="attr_ZfW_Gletscherwand" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -1505,6 +3022,21 @@
 						<button type="roll" name="roll_z_granitundmarmor" value="@{z_granitundmarmor_action}"> <span>Granit und Marmor</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_granit_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_granit">
 					<input type="number" class="talent-taw" name="attr_ZfW_granit" min="0" value="0">
 					<div class="talent-cell talent-taw">99</div>
@@ -1519,6 +3051,21 @@
 						<button type="roll" name="roll_z_dz_grolmenseele" value="@{z_dz_grolmenseele_action}"> <span>Grolmenseele</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Grolmenseele_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Grolmenseele">
 					<input type="number" class="talent-taw" name="attr_ZfW_Grolmenseele" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -1533,6 +3080,21 @@
 						<button type="roll" name="roll_z_grossegier" value="@{z_grossegier_action}"> <span>Große Gier</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_grossegier_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_grossegier">
 					<input type="number" class="talent-taw" name="attr_ZfW_grossegier" min="0" value="0">
 					<div class="talent-cell talent-taw">100</div>
@@ -1547,6 +3109,21 @@
 						<button type="roll" name="roll_z_grosseverwirrung" value="@{z_grosseverwirrung_action}"> <span>Große Verwirrung</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_grosseverwirrung_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_grosseverwirrung">
 					<input type="number" class="talent-taw" name="attr_ZfW_grosseverwirrung" min="0" value="0">
 					<div class="talent-cell talent-taw">101</div>
@@ -1561,6 +3138,21 @@
 						<button type="roll" name="roll_z_halluzination" value="@{z_halluzination_action}"> <span>Halluzination</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Halluzination_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Halluzination">
 					<input type="number" class="talent-taw" name="attr_ZfW_Halluzination" min="0" value="0">
 					<div class="talent-cell talent-taw">102</div>
@@ -1575,6 +3167,21 @@
 						<button type="roll" name="roll_z_harmlosegestalt" value="@{z_harmlosegestalt_action}"> <span>Harmlose Gestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Harmlose_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Harmlose">
 					<input type="number" class="talent-taw" name="attr_ZfW_Harmlose" min="0" value="0">
 					<div class="talent-cell talent-taw">103</div>
@@ -1589,6 +3196,21 @@
 						<button type="roll" name="roll_z_hartesschmelze" value="@{z_hartesschmelze_action}"> <span>Hartes schmelze!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_hartes_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_hartes">
 					<input type="number" class="talent-taw" name="attr_ZfW_hartes" min="0" value="0">
 					<div class="talent-cell talent-taw">104</div>
@@ -1603,6 +3225,21 @@
 						<button type="roll" name="roll_z_haselbusch" value="@{z_haselbusch_action}"> <span>Haselbusch und Ginsterkraut</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_haselbusch_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_haselbusch">
 					<input type="number" class="talent-taw" name="attr_ZfW_haselbusch" min="0" value="0">
 					<div class="talent-cell talent-taw">105</div>
@@ -1617,6 +3254,21 @@
 						<button type="roll" name="roll_z_dz_hauchdertiefentochter" value="@{z_dz_hauchdertiefentochter_action}"> <span>Hauch der Tiefen Tochter</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Hauch_der_Tiefen_Tochter_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Hauch_der_Tiefen_Tochter">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hauch_der_Tiefen_Tochter" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -1631,6 +3283,21 @@
 						<button type="roll" name="roll_z_heilkraftbannen" value="@{z_heilkraftbannen_action}"> <span>Heilkraft bannen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_heilkraft_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_heilkraft">
 					<input type="number" class="talent-taw" name="attr_ZfW_heilkraft" min="0" value="0">
 					<div class="talent-cell talent-taw">107</div>
@@ -1645,6 +3312,21 @@
 						<button type="roll" name="roll_z_hellsichttrueben" value="@{z_hellsichttrueben_action}"> <span>Hellsicht trüben</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_hellsicht_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_hellsicht">
 					<input type="number" class="talent-taw" name="attr_ZfW_hellsicht" min="0" value="0">
 					<div class="talent-cell talent-taw">108</div>
@@ -1659,6 +3341,21 @@
 						<button type="roll" name="roll_z_herbeirufungvereiteln" value="@{z_herbeirufungvereiteln_action}"> <span>Herbeirufung vereiteln</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_herbeirufung_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_herbeirufung">
 					<input type="number" class="talent-taw" name="attr_ZfW_herbeirufung" min="0" value="0">
 					<div class="talent-cell talent-taw">109</div>
@@ -1673,6 +3370,21 @@
 						<button type="roll" name="roll_z_herrueberdastierreich" value="@{z_herrueberdastierreich_action}"> <span>Herr über das Tierreich</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_herr_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_herr">
 					<input type="number" class="talent-taw" name="attr_ZfW_herr" min="0" value="0">
 					<div class="talent-cell talent-taw">110</div>
@@ -1687,6 +3399,21 @@
 						<button type="roll" name="roll_z_herzschlagruhe" value="@{z_herzschlagruhe_action}"> <span>Herzschlag ruhe!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_herzschlag_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_herzschlag">
 					<input type="number" class="talent-taw" name="attr_ZfW_herzschlag" min="0" value="0">
 					<div class="talent-cell talent-taw">111</div>
@@ -1701,6 +3428,21 @@
 						<button type="roll" name="roll_z_dz_hexagrammadschinnenbann" value="@{z_dz_hexagrammadschinnenbann_action}"> <span>Hexagramma Dschinnenbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/IN + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit und Modifikationen nach WdZ 187">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Hexagramma_Dschinnenbann_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Hexagramma_Dschinnenbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexagramma_Dschinnenbann" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -1715,6 +3457,21 @@
 						<button type="roll" name="roll_z_hexenblick" value="@{z_hexenblick_action}"> <span>Hexenblick</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Hexenblick_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenblick">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexenblick" min="0" value="0">
 					<div class="talent-cell talent-taw">112</div>
@@ -1729,6 +3486,21 @@
 						<button type="roll" name="roll_z_hexengalle" value="@{z_hexengalle_action}"> <span>Hexengalle</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Hexengalle_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexengalle">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexengalle" min="0" value="0">
 					<div class="talent-cell talent-taw">113</div>
@@ -1743,6 +3515,21 @@
 						<button type="roll" name="roll_z_hexenholz" value="@{z_hexenholz_action}"> <span>Hexenholz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Hexenholz_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenholz">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexenholz" min="0" value="0">
 					<div class="talent-cell talent-taw">114</div>
@@ -1757,6 +3544,21 @@
 						<button type="roll" name="roll_z_hexenknoten" value="@{z_hexenknoten_action}"> <span>Hexenknoten</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Hexenknoten_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenknoten">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexenknoten" min="0" value="0">
 					<div class="talent-cell talent-taw">115</div>
@@ -1771,6 +3573,21 @@
 						<button type="roll" name="roll_z_hexenkrallen" value="@{z_hexenkrallen_action}"> <span>Hexenkrallen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Hexenkrallen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenkrallen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexenkrallen" min="0" value="0">
 					<div class="talent-cell talent-taw">116</div>
@@ -1785,6 +3602,21 @@
 						<button type="roll" name="roll_z_hexenspeichel" value="@{z_hexenspeichel_action}"> <span>Hexenspeichel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Hexenspeichel_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenspeichel">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexenspeichel" min="0" value="0">
 					<div class="talent-cell talent-taw">117</div>
@@ -1799,6 +3631,21 @@
 						<button type="roll" name="roll_z_hilfreichetatze" value="@{z_hilfreichetatze_action}"> <span>Hilfreiche Tatze</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="geistige Magieresistenz des Tieres">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_hilfreiche_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_hilfreiche">
 					<input type="number" class="talent-taw" name="attr_ZfW_hilfreiche" min="0" value="0">
 					<div class="talent-cell talent-taw">118</div>
@@ -1813,6 +3660,21 @@
 						<button type="roll" name="roll_z_hoellenpein" value="@{z_hoellenpein_action}"> <span>Höllenpein zerreiße dich!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_hollenpein_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_hollenpein">
 					<input type="number" class="talent-taw" name="attr_ZfW_hollenpein" min="0" value="0">
 					<div class="talent-cell talent-taw">119</div>
@@ -1827,6 +3689,21 @@
 						<button type="roll" name="roll_z_holterdipolter" value="@{z_holterdipolter_action}"> <span>Holterdipolter</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Holterdipolter_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Holterdipolter">
 					<input type="number" class="talent-taw" name="attr_ZfW_Holterdipolter" min="0" value="0">
 					<div class="talent-cell talent-taw">120</div>
@@ -1841,6 +3718,21 @@
 						<button type="roll" name="roll_z_dz_hornissenruf" value="@{z_dz_hornissenruf_action}"> <span>Hornissenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Hornissenruf_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Hornissenruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hornissenruf" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -1855,6 +3747,21 @@
 						<button type="roll" name="roll_z_horriphobus" value="@{z_horriphobus_action}"> <span>Horriphobus Schreckgestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz vermindert um Aberglauben und Ängste">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_horriphobus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_horriphobus">
 					<input type="number" class="talent-taw" name="attr_ZfW_horriphobus" min="0" value="0">
 					<div class="talent-cell talent-taw">121</div>
@@ -1869,6 +3776,21 @@
 						<button type="roll" name="roll_z_humofaxius" value="@{z_humofaxius_action}"> <span>Humofaxius</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Humofaxius_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Humofaxius">
 					<input type="number" class="talent-taw" name="attr_ZfW_Humofaxius" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -1883,6 +3805,21 @@
 						<button type="roll" name="roll_z_humosphaero" value="@{z_humosphaero_action}"> <span>Humosphaero</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Humosphaero_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Humosphaero">
 					<input type="number" class="talent-taw" name="attr_ZfW_Humosphaero" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -1897,6 +3834,21 @@
 						<button type="roll" name="roll_z_ignifaxius" value="@{z_ignifaxius_action}"> <span>Ignifaxius Flammenstrahl</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_ignifaxius_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ignifaxius">
 					<input type="number" class="talent-taw" name="attr_ZfW_ignifaxius" min="0" value="0">
 					<div class="talent-cell talent-taw">122</div>
@@ -1911,6 +3863,21 @@
 						<button type="roll" name="roll_z_dz_igniflumenflammenspur" value="@{z_dz_igniflumenflammenspur_action}"> <span>Igniflumen Flammenspur</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Igniflumen_Flammenspur_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Igniflumen_Flammenspur">
 					<input type="number" class="talent-taw" name="attr_ZfW_Igniflumen_Flammenspur" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -1925,6 +3892,21 @@
 						<button type="roll" name="roll_z_ignifugo" value="@{z_ignifugo_action}"> <span>Ignifugo Feuerbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Ignifugo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Ignifugo">
 					<input type="number" class="talent-taw" name="attr_ZfW_Ignifugo" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -1939,6 +3921,21 @@
 						<button type="roll" name="roll_z_ignimorpho" value="@{z_ignimorpho_action}"> <span>Ignimorpho Feuerform</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Ignimorpho_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Ignimorpho">
 					<input type="number" class="talent-taw" name="attr_ZfW_Ignimorpho" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -1953,6 +3950,21 @@
 						<button type="roll" name="roll_z_igniplano" value="@{z_igniplano_action}"> <span>Igniplano Flächenbrand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Igniplano_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Igniplano">
 					<input type="number" class="talent-taw" name="attr_ZfW_Igniplano" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -1967,6 +3979,21 @@
 						<button type="roll" name="roll_z_dz_igniquerisfeuerkragen" value="@{z_dz_igniquerisfeuerkragen_action}"> <span>Igniqueris Feuerkragen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Igniqueris_Feuerkragen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Igniqueris_Feuerkragen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Igniqueris_Feuerkragen" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -1981,6 +4008,21 @@
 						<button type="roll" name="roll_z_ignisphaero" value="@{z_ignisphaero_action}"> <span>Ignisphaero Feuerball</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_ignisphaero_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ignisphaero">
 					<input type="number" class="talent-taw" name="attr_ZfW_ignisphaero" min="0" value="0">
 					<div class="talent-cell talent-taw">124</div>
@@ -1995,6 +4037,21 @@
 						<button type="roll" name="roll_z_ignorantia" value="@{z_ignorantia_action}"> <span>Ignorantia Ungesehn</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_ignorantia_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ignorantia">
 					<input type="number" class="talent-taw" name="attr_ZfW_ignorantia" min="0" value="0">
 					<div class="talent-cell talent-taw">125</div>
@@ -2009,6 +4066,21 @@
 						<button type="roll" name="roll_z_illusionaufloesen" value="@{z_illusionaufloesen_action}"> <span>Illusion auflösen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_illusion_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_illusion">
 					<input type="number" class="talent-taw" name="attr_ZfW_illusion" min="0" value="0">
 					<div class="talent-cell talent-taw">126</div>
@@ -2023,6 +4095,21 @@
 						<button type="roll" name="roll_z_immortalis" value="@{z_immortalis_action}"> <span>Immortalis Lebenszeit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_immortalis_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_immortalis">
 					<input type="number" class="talent-taw" name="attr_ZfW_immortalis" min="0" value="0">
 					<div class="talent-cell talent-taw">127</div>
@@ -2037,6 +4124,21 @@
 						<button type="roll" name="roll_z_imperavi" value="@{z_imperavi_action}"> <span>Imperavi Handlungszwang</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_imperavi_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_imperavi">
 					<input type="number" class="talent-taw" name="attr_ZfW_imperavi" min="0" value="0">
 					<div class="talent-cell talent-taw">128</div>
@@ -2051,6 +4153,21 @@
 						<button type="roll" name="roll_z_impersona" value="@{z_impersona_action}"> <span>Impersona Maskenbild</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Vertrautheit des Gesichtes">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_impersona_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_impersona">
 					<input type="number" class="talent-taw" name="attr_ZfW_impersona" min="0" value="0">
 					<div class="talent-cell talent-taw">129</div>
@@ -2065,6 +4182,21 @@
 						<button type="roll" name="roll_z_infinitum" value="@{z_infinitum_action}"> <span>Infinitum Immerdar</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO + <span class="abbr" title="Modifikator für die Kosten des zu verlängernden Zaubers">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_infinitum_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_infinitum">
 					<input type="number" class="talent-taw" name="attr_ZfW_infinitum" min="0" value="0">
 					<div class="talent-cell talent-taw">130</div>
@@ -2079,6 +4211,21 @@
 						<button type="roll" name="roll_z_invercano" value="@{z_invercano_action}"> <span>Invercano Spiegeltrick</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_invercano_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_invercano">
 					<input type="number" class="talent-taw" name="attr_ZfW_invercano" min="0" value="0">
 					<div class="talent-cell talent-taw">131</div>
@@ -2093,6 +4240,21 @@
 						<button type="roll" name="roll_z_invocatiomaior" value="@{z_invocatiomaior_action}"> <span>Invocatio Maior</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Dämons">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_invocatiomaior_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_invocatiomaior">
 					<input type="number" class="talent-taw" name="attr_ZfW_invocatiomaior" min="0" value="0">
 					<div class="talent-cell talent-taw">132</div>
@@ -2107,6 +4269,21 @@
 						<button type="roll" name="roll_z_invocatiominor" value="@{z_invocatiominor_action}"> <span>Invocatio Minor</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Dämons">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_invocatiominor_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_invocatiominor">
 					<input type="number" class="talent-taw" name="attr_ZfW_invocatiominor" min="0" value="0">
 					<div class="talent-cell talent-taw">133</div>
@@ -2121,6 +4298,21 @@
 						<button type="roll" name="roll_z_iribaarshand" value="@{z_iribaarshand_action}"> <span>Iribaars Hand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/IN + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_iribaars_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_iribaars">
 					<input type="number" class="talent-taw" name="attr_ZfW_iribaars" min="0" value="0">
 					<div class="talent-cell talent-taw">134</div>
@@ -2135,6 +4327,21 @@
 						<button type="roll" name="roll_z_juckreiz" value="@{z_juckreiz_action}"> <span>Juckreiz, dämlicher!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_juckreiz_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_juckreiz">
 					<input type="number" class="talent-taw" name="attr_ZfW_juckreiz" min="0" value="0">
 					<div class="talent-cell talent-taw">135</div>
@@ -2149,6 +4356,21 @@
 						<button type="roll" name="roll_z_karnifilo" value="@{z_karnifilo_action}"> <span>Karnifilo Raserei</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_karnifilo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_karnifilo">
 					<input type="number" class="talent-taw" name="attr_ZfW_karnifilo" min="0" value="0">
 					<div class="talent-cell talent-taw">136</div>
@@ -2163,6 +4385,21 @@
 						<button type="roll" name="roll_z_katzenaugen" value="@{z_katzenaugen_action}"> <span>Katzenaugen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Katzenaugen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Katzenaugen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Katzenaugen" min="0" value="0">
 					<div class="talent-cell talent-taw">137</div>
@@ -2177,6 +4414,21 @@
 						<button type="roll" name="roll_z_klarumpurum" value="@{z_klarumpurum_action}"> <span>Klarum Purum</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/CH + <span class="abbr" title="Modifikator für die Giftstufe">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_klarum_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_klarum">
 					<input type="number" class="talent-taw" name="attr_ZfW_klarum" min="0" value="0">
 					<div class="talent-cell talent-taw">138</div>
@@ -2191,6 +4443,21 @@
 						<button type="roll" name="roll_z_klickeradomms" value="@{z_klickeradomms_action}"> <span>Klickeradomms</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Klickeradomms_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Klickeradomms">
 					<input type="number" class="talent-taw" name="attr_ZfW_Klickeradomms" min="0" value="0">
 					<div class="talent-cell talent-taw">139</div>
@@ -2205,6 +4472,21 @@
 						<button type="roll" name="roll_z_koboldgeschenk" value="@{z_koboldgeschenk_action}"> <span>Koboldgeschenk</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Koboldgeschenk_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Koboldgeschenk">
 					<input type="number" class="talent-taw" name="attr_ZfW_Koboldgeschenk" min="0" value="0">
 					<div class="talent-cell talent-taw">140</div>
@@ -2219,6 +4501,21 @@
 						<button type="roll" name="roll_z_koboldovision" value="@{z_koboldovision_action}"> <span>Koboldovision</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Koboldovision_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Koboldovision">
 					<input type="number" class="talent-taw" name="attr_ZfW_Koboldovision" min="0" value="0">
 					<div class="talent-cell talent-taw">141</div>
@@ -2233,6 +4530,21 @@
 						<button type="roll" name="roll_z_kommkoboldkomm" value="@{z_kommkoboldkomm_action}"> <span>Komm Kobold Komm</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_komm_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_komm">
 					<input type="number" class="talent-taw" name="attr_ZfW_komm" min="0" value="0">
 					<div class="talent-cell talent-taw">142</div>
@@ -2247,6 +4559,21 @@
 						<button type="roll" name="roll_z_koerperlosereise" value="@{z_koerperlosereise_action}"> <span>Körperlose Reise</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_koerperlose_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_koerperlose">
 					<input type="number" class="talent-taw" name="attr_ZfW_koerperlose" min="0" value="0">
 					<div class="talent-cell talent-taw">143</div>
@@ -2261,6 +4588,21 @@
 						<button type="roll" name="roll_z_krabbelnderschrecken" value="@{z_krabbelnderschrecken_action}"> <span>Krabbelnder Schrecken</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_krabbelnder_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_krabbelnder">
 					<input type="number" class="talent-taw" name="attr_ZfW_krabbelnder" min="0" value="0">
 					<div class="talent-cell talent-taw">144</div>
@@ -2275,6 +4617,21 @@
 						<button type="roll" name="roll_z_kraftdeserzes" value="@{z_kraftdeserzes_action}"> <span>Kraft des Erzes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_kraft_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_kraft">
 					<input type="number" class="talent-taw" name="attr_ZfW_kraft" min="0" value="0">
 					<div class="talent-cell talent-taw">145</div>
@@ -2289,6 +4646,21 @@
 						<button type="roll" name="roll_z_kraftdeshumus" value="@{z_kraftdeshumus_action}"> <span>Kraft des Humus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_kraft_humus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_kraft_humus">
 					<input type="number" class="talent-taw" name="attr_ZfW_kraft_humus" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -2303,6 +4675,21 @@
 						<button type="roll" name="roll_z_kraehenruf" value="@{z_kraehenruf_action}"> <span>Krähenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_krahenruf_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_krahenruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_krahenruf" min="0" value="0">
 					<div class="talent-cell talent-taw">146</div>
@@ -2317,6 +4704,21 @@
 						<button type="roll" name="roll_z_kroetensprung" value="@{z_kroetensprung_action}"> <span>Krötensprung</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_krotensprung_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_krotensprung">
 					<input type="number" class="talent-taw" name="attr_ZfW_krotensprung" min="0" value="0">
 					<div class="talent-cell talent-taw">148</div>
@@ -2331,6 +4733,21 @@
 						<button type="roll" name="roll_z_kulminatio" value="@{z_kulminatio_action}"> <span>Kulminatio Kugelblitz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_kulminatio_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_kulminatio">
 					<input type="number" class="talent-taw" name="attr_ZfW_kulminatio" min="0" value="0">
 					<div class="talent-cell talent-taw">149</div>
@@ -2345,6 +4762,21 @@
 						<button type="roll" name="roll_z_kusch" value="@{z_kusch_action}"> <span>Kusch!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_kusch_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_kusch">
 					<input type="number" class="talent-taw" name="attr_ZfW_kusch" min="0" value="0">
 					<div class="talent-cell talent-taw">150</div>
@@ -2359,6 +4791,21 @@
 						<button type="roll" name="roll_z_lachdichgesund" value="@{z_lachdichgesund_action}"> <span>Lach dich gesund</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_lach_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_lach">
 					<input type="number" class="talent-taw" name="attr_ZfW_lach" min="0" value="0">
 					<div class="talent-cell talent-taw">151</div>
@@ -2373,6 +4820,21 @@
 						<button type="roll" name="roll_z_lachkrampf" value="@{z_lachkrampf_action}"> <span>Lachkrampf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Lachkrampf_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Lachkrampf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Lachkrampf" min="0" value="0">
 					<div class="talent-cell talent-taw">152</div>
@@ -2387,6 +4849,21 @@
 						<button type="roll" name="roll_z_langerlulatsch" value="@{z_langerlulatsch_action}"> <span>Langer Lulatsch</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/GE/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_langer_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_langer">
 					<input type="number" class="talent-taw" name="attr_ZfW_langer" min="0" value="0">
 					<div class="talent-cell talent-taw">153</div>
@@ -2401,6 +4878,21 @@
 						<button type="roll" name="roll_z_lastdesalters" value="@{z_lastdesalters_action}"> <span>Last des Alters</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_last_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_last">
 					<input type="number" class="talent-taw" name="attr_ZfW_last" min="0" value="0">
 					<div class="talent-cell talent-taw">154</div>
@@ -2415,6 +4907,21 @@
 						<button type="roll" name="roll_z_dz_leibaustausendfliegen" value="@{z_dz_leibaustausendfliegen_action}"> <span>Leib aus tausend Fliegen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Leib_aus_tausend_Fliegen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Leib_aus_tausend_Fliegen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Leib_aus_tausend_Fliegen" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -2429,6 +4936,21 @@
 						<button type="roll" name="roll_z_leibdererde" value="@{z_leibdererde_action}"> <span>Leib der Erde</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_leibdererde_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdererde">
 					<input type="number" class="talent-taw" name="attr_ZfW_leibdererde" min="0" value="0">
 					<div class="talent-cell talent-taw">155</div>
@@ -2443,6 +4965,21 @@
 						<button type="roll" name="roll_z_leibderwogen" value="@{z_leibderwogen_action}"> <span>Leib der Wogen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_leibderwogen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibderwogen">
 					<input type="number" class="talent-taw" name="attr_ZfW_leibderwogen" min="0" value="0">
 					<div class="talent-cell talent-taw">157</div>
@@ -2457,6 +4994,21 @@
 						<button type="roll" name="roll_z_leibdeseises" value="@{z_leibdeseises_action}"> <span>Leib des Eises</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_leibdeseises_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdeseises">
 					<input type="number" class="talent-taw" name="attr_ZfW_leibdeseises" min="0" value="0">
 					<div class="talent-cell talent-taw">159</div>
@@ -2471,6 +5023,21 @@
 						<button type="roll" name="roll_z_leibdeserzes" value="@{z_leibdeserzes_action}"> <span>Leib des Erzes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/GE/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_leibdeserzes_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdeserzes">
 					<input type="number" class="talent-taw" name="attr_ZfW_leibdeserzes" min="0" value="0">
 					<div class="talent-cell talent-taw">160</div>
@@ -2485,6 +5052,21 @@
 						<button type="roll" name="roll_z_leibdesfeuers" value="@{z_leibdesfeuers_action}"> <span>Leib des Feuers</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_leibdesfeuers_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdesfeuers">
 					<input type="number" class="talent-taw" name="attr_ZfW_leibdesfeuers" min="0" value="0">
 					<div class="talent-cell talent-taw">162</div>
@@ -2499,6 +5081,21 @@
 						<button type="roll" name="roll_z_leibdeswindes" value="@{z_leibdeswindes_action}"> <span>Leib des Windes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/GE/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_leibdeswindes_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdeswindes">
 					<input type="number" class="talent-taw" name="attr_ZfW_leibdeswindes" min="0" value="0">
 					<div class="talent-cell talent-taw">164</div>
@@ -2513,6 +5110,21 @@
 						<button type="roll" name="roll_z_leidensbund" value="@{z_leidensbund_action}"> <span>Leidensbund</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Leidensbund_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Leidensbund">
 					<input type="number" class="talent-taw" name="attr_ZfW_Leidensbund" min="0" value="0">
 					<div class="talent-cell talent-taw">165</div>
@@ -2527,6 +5139,21 @@
 						<button type="roll" name="roll_z_levthansfeuer" value="@{z_levthansfeuer_action}"> <span>Levthans Feuer</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_levthans_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_levthans">
 					<input type="number" class="talent-taw" name="attr_ZfW_levthans" min="0" value="0">
 					<div class="talent-cell talent-taw">166</div>
@@ -2541,6 +5168,21 @@
 						<button type="roll" name="roll_z_limbusversiegeln" value="@{z_limbusversiegeln_action}"> <span>Limbus versiegeln</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_limbus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_limbus">
 					<input type="number" class="talent-taw" name="attr_ZfW_limbus" min="0" value="0">
 					<div class="talent-cell talent-taw">167</div>
@@ -2555,6 +5197,21 @@
 						<button type="roll" name="roll_z_lockruf" value="@{z_lockruf_action}"> <span>Lockruf und Feenfüße</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_lockruf_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_lockruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_lockruf" min="0" value="0">
 					<div class="talent-cell talent-taw">168</div>
@@ -2569,6 +5226,21 @@
 						<button type="roll" name="roll_z_lungedesleviatan" value="@{z_lungedesleviatan_action}"> <span>Lunge des Leviatan</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_lunge_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_lunge">
 					<input type="number" class="talent-taw" name="attr_ZfW_lunge" min="0" value="0">
 					<div class="talent-cell talent-taw">169</div>
@@ -2583,6 +5255,21 @@
 						<button type="roll" name="roll_z_madasspiegel" value="@{z_madasspiegel_action}"> <span>Madas Spiegel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_madas_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_madas">
 					<input type="number" class="talent-taw" name="attr_ZfW_madas" min="0" value="0">
 					<div class="talent-cell talent-taw">170</div>
@@ -2597,6 +5284,21 @@
 						<button type="roll" name="roll_z_magischerraub" value="@{z_magischerraub_action}"> <span>Magischer Raub</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_magischer_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_magischer">
 					<input type="number" class="talent-taw" name="attr_ZfW_magischer" min="0" value="0">
 					<div class="talent-cell talent-taw">171</div>
@@ -2611,6 +5313,21 @@
 						<button type="roll" name="roll_z_mahlstrom" value="@{z_mahlstrom_action}"> <span>Mahlstrom</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Mahlstrom_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Mahlstrom">
 					<input type="number" class="talent-taw" name="attr_ZfW_Mahlstrom" min="0" value="0">
 					<div class="talent-cell talent-taw">172</div>
@@ -2625,6 +5342,21 @@
 						<button type="roll" name="roll_z_malmkreis" value="@{z_malmkreis_action}"> <span>Malmkreis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Malmkreis_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Malmkreis">
 					<input type="number" class="talent-taw" name="attr_ZfW_Malmkreis" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -2639,6 +5371,21 @@
 						<button type="roll" name="roll_z_manifesto" value="@{z_manifesto_action}"> <span>Manifesto Element</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Komplexität der Manifestation">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_manifesto_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_manifesto">
 					<input type="number" class="talent-taw" name="attr_ZfW_manifesto" min="0" value="0">
 					<div class="talent-cell talent-taw">173</div>
@@ -2653,6 +5400,21 @@
 						<button type="roll" name="roll_z_meisterderelemente" value="@{z_meisterderelemente_action}"> <span>Meister der Elemente</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_meisterderelemente_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_meisterderelemente">
 					<input type="number" class="talent-taw" name="attr_ZfW_meisterderelemente" min="0" value="0">
 					<div class="talent-cell talent-taw">174</div>
@@ -2667,6 +5429,21 @@
 						<button type="roll" name="roll_z_meisterminderergeister" value="@{z_meisterminderergeister_action}"> <span>Meister minderer Geister</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_meisterminderergeister_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_meisterminderergeister">
 					<input type="number" class="talent-taw" name="attr_ZfW_meisterminderergeister" min="0" value="0">
 					<div class="talent-cell talent-taw">175</div>
@@ -2681,6 +5458,21 @@
 						<button type="roll" name="roll_z_memorabia" value="@{z_memorabia_action}"> <span>Memorabia Falsifir</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Dauer des getilgten Zeitabschnitts, der Zeitpunkt, ab dem getilgt werden soll, die Tiefe des Wissens und Hilfsmitteln">Mod.</span> + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_memorabia_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_memorabia">
 					<input type="number" class="talent-taw" name="attr_ZfW_memorabia" min="0" value="0">
 					<div class="talent-cell talent-taw">176</div>
@@ -2695,6 +5487,21 @@
 						<button type="roll" name="roll_z_memorans" value="@{z_memorans_action}"> <span>Memorans Gedächtniskraft</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_memorans_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_memorans">
 					<input type="number" class="talent-taw" name="attr_ZfW_memorans" min="0" value="0">
 					<div class="talent-cell talent-taw">177</div>
@@ -2709,6 +5516,21 @@
 						<button type="roll" name="roll_z_menetekel" value="@{z_menetekel_action}"> <span>Menetekel Flammenschrift</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_menetekel_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_menetekel">
 					<input type="number" class="talent-taw" name="attr_ZfW_menetekel" min="0" value="0">
 					<div class="talent-cell talent-taw">178</div>
@@ -2723,6 +5545,21 @@
 						<button type="roll" name="roll_z_metamagieneutralisieren" value="@{z_metamagieneutralisieren_action}"> <span>Metamagie neutralisieren</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_metamagie_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_metamagie">
 					<input type="number" class="talent-taw" name="attr_ZfW_metamagie" min="0" value="0">
 					<div class="talent-cell talent-taw">179</div>
@@ -2737,6 +5574,21 @@
 						<button type="roll" name="roll_z_metamorphofelsenform" value="@{z_metamorphofelsenform_action}"> <span>Metamorpho Felsenform</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_metamorpho_felsenform_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_metamorpho_felsenform">
 					<input type="number" class="talent-taw" name="attr_ZfW_metamorpho_felsenform" min="0" value="0">
 					<div class="talent-cell talent-taw">180</div>
@@ -2751,6 +5603,21 @@
 						<button type="roll" name="roll_z_metamorphogletscherform" value="@{z_metamorphogletscherform_action}"> <span>Metamorpho Gletscherform</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_metamorpho_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_metamorpho">
 					<input type="number" class="talent-taw" name="attr_ZfW_metamorpho" min="0" value="0">
 					<div class="talent-cell talent-taw">180</div>
@@ -2765,6 +5632,21 @@
 						<button type="roll" name="roll_z_motoricus" value="@{z_motoricus_action}"> <span>Motoricus Geisteshand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_motoricus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_motoricus">
 					<input type="number" class="talent-taw" name="attr_ZfW_motoricus" min="0" value="0">
 					<div class="talent-cell talent-taw">181</div>
@@ -2779,6 +5661,21 @@
 						<button type="roll" name="roll_z_movimento" value="@{z_movimento_action}"> <span>Movimento Dauerlauf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_movimento_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_movimento">
 					<input type="number" class="talent-taw" name="attr_ZfW_movimento" min="0" value="0">
 					<div class="talent-cell talent-taw">183</div>
@@ -2793,6 +5690,21 @@
 						<button type="roll" name="roll_z_murksundpatz" value="@{z_murksundpatz_action}"> <span>Murks und Patz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF + <span class="abbr" title="höchste Magieresistenz plus Anzahl Betroffener">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_murks_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_murks">
 					<input type="number" class="talent-taw" name="attr_ZfW_murks" min="0" value="0">
 					<div class="talent-cell talent-taw">184</div>
@@ -2807,6 +5719,21 @@
 						<button type="roll" name="roll_z_nackedei" value="@{z_nackedei_action}"> <span>Nackedei</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Gesamtrüstschutz des Opfers">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Nackedei_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Nackedei">
 					<input type="number" class="talent-taw" name="attr_ZfW_Nackedei" min="0" value="0">
 					<div class="talent-cell talent-taw">185</div>
@@ -2821,6 +5748,21 @@
 						<button type="roll" name="roll_z_nebelleib" value="@{z_nebelleib_action}"> <span>Nebelleib</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Nebelleib_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Nebelleib">
 					<input type="number" class="talent-taw" name="attr_ZfW_Nebelleib" min="0" value="0">
 					<div class="talent-cell talent-taw">186</div>
@@ -2835,6 +5777,21 @@
 						<button type="roll" name="roll_z_nebelwand" value="@{z_nebelwand_action}"> <span>Nebelwand und Morgendunst</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_nebelwand_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_nebelwand">
 					<input type="number" class="talent-taw" name="attr_ZfW_nebelwand" min="0" value="0">
 					<div class="talent-cell talent-taw">187</div>
@@ -2849,6 +5806,21 @@
 						<button type="roll" name="roll_z_nekropathia" value="@{z_nekropathia_action}"> <span>Nekropathia Seelenreise</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_nekropathia_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_nekropathia">
 					<input type="number" class="talent-taw" name="attr_ZfW_nekropathia" min="0" value="0">
 					<div class="talent-cell talent-taw">188</div>
@@ -2863,6 +5835,21 @@
 						<button type="roll" name="roll_z_nihilogravo" value="@{z_nihilogravo_action}"> <span>Nihilogravo Schwerelos</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_nihilogravo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_nihilogravo">
 					<input type="number" class="talent-taw" name="attr_ZfW_nihilogravo" min="0" value="0">
 					<div class="talent-cell talent-taw">189</div>
@@ -2877,6 +5864,21 @@
 						<button type="roll" name="roll_z_nuntiovolo" value="@{z_nuntiovolo_action}"> <span>Nuntiovolo Botenvogel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_nuntiovolo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_nuntiovolo">
 					<input type="number" class="talent-taw" name="attr_ZfW_nuntiovolo" min="0" value="0">
 					<div class="talent-cell talent-taw">190</div>
@@ -2891,6 +5893,21 @@
 						<button type="roll" name="roll_z_objectoobscuro" value="@{z_objectoobscuro_action}"> <span>Objecto Obscuro</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_objecto_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_objecto">
 					<input type="number" class="talent-taw" name="attr_ZfW_objecto" min="0" value="0">
 					<div class="talent-cell talent-taw">191</div>
@@ -2905,6 +5922,21 @@
 						<button type="roll" name="roll_z_objectofixo" value="@{z_objectofixo_action}"> <span>Objectofixo</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Objectofixo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Objectofixo">
 					<input type="number" class="talent-taw" name="attr_ZfW_Objectofixo" min="0" value="0">
 					<div class="talent-cell talent-taw">192</div>
@@ -2919,6 +5951,21 @@
 						<button type="roll" name="roll_z_objectovoco" value="@{z_objectovoco_action}"> <span>Objectovoco</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_objectovoco_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_objectovoco">
 					<input type="number" class="talent-taw" name="attr_ZfW_objectovoco" min="0" value="0">
 					<div class="talent-cell talent-taw">193</div>
@@ -2933,6 +5980,21 @@
 						<button type="roll" name="roll_z_objektentzaubern" value="@{z_objektentzaubern_action}"> <span>Objekt entzaubern</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_objekt_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_objekt">
 					<input type="number" class="talent-taw" name="attr_ZfW_objekt" min="0" value="0">
 					<div class="talent-cell talent-taw">194</div>
@@ -2947,6 +6009,21 @@
 						<button type="roll" name="roll_z_oculus" value="@{z_oculus_action}"> <span>Oculus Astralis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_oculus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_oculus">
 					<input type="number" class="talent-taw" name="attr_ZfW_oculus" min="0" value="0">
 					<div class="talent-cell talent-taw">196</div>
@@ -2961,6 +6038,21 @@
 						<button type="roll" name="roll_z_odem" value="@{z_odem_action}"> <span>Odem Arcanum</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/IN + <span class="abbr" title="Modifikator für die im Zielobjekt permanent gebundenen Astralpunkte, dem Astralenergievorrat des Zielwesens, der Zeit seit dem Vergehen des Zaubers oder der Art des magischen Wesens">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_odem_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_odem">
 					<input type="number" class="talent-taw" name="attr_ZfW_odem" min="0" value="0">
 					<div class="talent-cell talent-taw">197</div>
@@ -2975,6 +6067,21 @@
 						<button type="roll" name="roll_z_orcanofaxius" value="@{z_orcanofaxius_action}"> <span>Orcanofaxius</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Orcanofaxius_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Orcanofaxius">
 					<input type="number" class="talent-taw" name="attr_ZfW_Orcanofaxius" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -2989,6 +6096,21 @@
 						<button type="roll" name="roll_z_orcanosphaero" value="@{z_orcanosphaero_action}"> <span>Orcanosphaero</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Orcanosphaero_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Orcanosphaero">
 					<input type="number" class="talent-taw" name="attr_ZfW_Orcanosphaero" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -3003,6 +6125,21 @@
 						<button type="roll" name="roll_z_pandaemonium" value="@{z_pandaemonium_action}"> <span>Pandaemonium</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Größe des dämonenverseuchten Gebiets">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Pandaemonium_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Pandaemonium">
 					<input type="number" class="talent-taw" name="attr_ZfW_Pandaemonium" min="0" value="0">
 					<div class="talent-cell talent-taw">199</div>
@@ -3017,6 +6154,21 @@
 						<button type="roll" name="roll_z_panik" value="@{z_panik_action}"> <span>Panik überkomme euch!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_panik_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_panik">
 					<input type="number" class="talent-taw" name="attr_ZfW_panik" min="0" value="0">
 					<div class="talent-cell talent-taw">200</div>
@@ -3031,6 +6183,21 @@
 						<button type="roll" name="roll_z_papperlapapp" value="@{z_papperlapapp_action}"> <span>Papperlapapp</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Papperlapapp_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Papperlapapp">
 					<input type="number" class="talent-taw" name="attr_ZfW_Papperlapapp" min="0" value="0">
 					<div class="talent-cell talent-taw">201</div>
@@ -3045,6 +6212,21 @@
 						<button type="roll" name="roll_z_paralysis" value="@{z_paralysis_action}"> <span>Paralysis starr wie Stein</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_paralys_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_paralys">
 					<input type="number" class="talent-taw" name="attr_ZfW_paralys" min="0" value="0">
 					<div class="talent-cell talent-taw">202</div>
@@ -3059,6 +6241,21 @@
 						<button type="roll" name="roll_z_pectetondo" value="@{z_pectetondo_action}"> <span>Pectetondo Zauberhaar</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pectetondo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pectetondo">
 					<input type="number" class="talent-taw" name="attr_ZfW_pectetondo" min="0" value="0">
 					<div class="talent-cell talent-taw">203</div>
@@ -3073,6 +6270,21 @@
 						<button type="roll" name="roll_z_penetrizzel" value="@{z_penetrizzel_action}"> <span>Penetrizzel Tiefenblick</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_penetrizzel_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_penetrizzel">
 					<input type="number" class="talent-taw" name="attr_ZfW_penetrizzel" min="0" value="0">
 					<div class="talent-cell talent-taw">204</div>
@@ -3087,6 +6299,21 @@
 						<button type="roll" name="roll_z_pentagramma" value="@{z_pentagramma_action}"> <span>Pentagramma Sphärenbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit, die Art des Wesens, bestimmter dämonischer Eigenheiten, Kenntnis des wahren Namens, Bannschwert, korrekte Bekleidung und passende Donaria">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pentagramma_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pentagramma">
 					<input type="number" class="talent-taw" name="attr_ZfW_pentagramma" min="0" value="0">
 					<div class="talent-cell talent-taw">205</div>
@@ -3101,6 +6328,21 @@
 						<button type="roll" name="roll_z_pestilenzerspueren" value="@{z_pestilenzerspueren_action}"> <span>Pestilenz erspüren</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Entdeckungsschwierigkeit der Krankheit oder der Giftstufe des Giftes">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pestilenz_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pestilenz">
 					<input type="number" class="talent-taw" name="attr_ZfW_pestilenz" min="0" value="0">
 					<div class="talent-cell talent-taw">207</div>
@@ -3115,6 +6357,21 @@
 						<button type="roll" name="roll_z_pfeilderluft" value="@{z_pfeilderluft_action}"> <span>Pfeil der Luft</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pfeilderluft_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeilderluft">
 					<input type="number" class="talent-taw" name="attr_ZfW_pfeilderluft" min="0" value="0">
 					<div class="talent-cell talent-taw">208</div>
@@ -3129,6 +6386,21 @@
 						<button type="roll" name="roll_z_pfeildeseises" value="@{z_pfeildeseises_action}"> <span>Pfeil des Eises</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pfeildeseises_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildeseises">
 					<input type="number" class="talent-taw" name="attr_ZfW_pfeildeseises" min="0" value="0">
 					<div class="talent-cell talent-taw">208</div>
@@ -3143,6 +6415,21 @@
 						<button type="roll" name="roll_z_pfeildeserzes" value="@{z_pfeildeserzes_action}"> <span>Pfeil des Erzes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pfeildeserzes_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildeserzes">
 					<input type="number" class="talent-taw" name="attr_ZfW_pfeildeserzes" min="0" value="0">
 					<div class="talent-cell talent-taw">208</div>
@@ -3157,6 +6444,21 @@
 						<button type="roll" name="roll_z_pfeildesfeuers" value="@{z_pfeildesfeuers_action}"> <span>Pfeil des Feuers</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pfeildesfeuers_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildesfeuers">
 					<input type="number" class="talent-taw" name="attr_ZfW_pfeildesfeuers" min="0" value="0">
 					<div class="talent-cell talent-taw">208</div>
@@ -3171,6 +6473,21 @@
 						<button type="roll" name="roll_z_pfeildeshumus" value="@{z_pfeildeshumus_action}"> <span>Pfeil des Humus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pfeildeshumus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildeshumus">
 					<input type="number" class="talent-taw" name="attr_ZfW_pfeildeshumus" min="0" value="0">
 					<div class="talent-cell talent-taw">208</div>
@@ -3185,6 +6502,21 @@
 						<button type="roll" name="roll_z_pfeildeswassers" value="@{z_pfeildeswassers_action}"> <span>Pfeil des Wassers</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pfeildeswassers_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildeswassers">
 					<input type="number" class="talent-taw" name="attr_ZfW_pfeildeswassers" min="0" value="0">
 					<div class="talent-cell talent-taw">208</div>
@@ -3199,6 +6531,21 @@
 						<button type="roll" name="roll_z_planastrale" value="@{z_planastrale_action}"> <span>Planastrale Anderswelt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_planastrale_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_planastrale">
 					<input type="number" class="talent-taw" name="attr_ZfW_planastrale" min="0" value="0">
 					<div class="talent-cell talent-taw">210</div>
@@ -3213,6 +6560,21 @@
 						<button type="roll" name="roll_z_plumbumbarum" value="@{z_plumbumbarum_action}"> <span>Plumbumbarum schwerer Arm</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/GE/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_plumbumbarum_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_plumbumbarum">
 					<input type="number" class="talent-taw" name="attr_ZfW_plumbumbarum" min="0" value="0">
 					<div class="talent-cell talent-taw">211</div>
@@ -3227,6 +6589,21 @@
 						<button type="roll" name="roll_z_projektimago" value="@{z_projektimago_action}"> <span>Projektimago Ebenbild</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Entfernung zwischen Magier und Projektion">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_projektimago_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_projektimago">
 					<input type="number" class="talent-taw" name="attr_ZfW_projektimago" min="0" value="0">
 					<div class="talent-cell talent-taw">212</div>
@@ -3241,6 +6618,21 @@
 						<button type="roll" name="roll_z_protectionis" value="@{z_protectionis_action}"> <span>Protectionis Kontrabann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_protectionis_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_protectionis">
 					<input type="number" class="talent-taw" name="attr_ZfW_protectionis" min="0" value="0">
 					<div class="talent-cell talent-taw">213</div>
@@ -3255,6 +6647,21 @@
 						<button type="roll" name="roll_z_psychostabilis" value="@{z_psychostabilis_action}"> <span>Psychostabilis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_psychostabilis_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_psychostabilis">
 					<input type="number" class="talent-taw" name="attr_ZfW_psychostabilis" min="0" value="0">
 					<div class="talent-cell talent-taw">214</div>
@@ -3269,6 +6676,21 @@
 						<button type="roll" name="roll_z_radau" value="@{z_radau_action}"> <span>Radau</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_radau_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_radau">
 					<input type="number" class="talent-taw" name="attr_ZfW_radau" min="0" value="0">
 					<div class="talent-cell talent-taw">215</div>
@@ -3283,6 +6705,21 @@
 						<button type="roll" name="roll_z_reflectimago" value="@{z_reflectimago_action}"> <span>Reflectimago Spiegelschein</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_reflectimago_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_reflectimago">
 					<input type="number" class="talent-taw" name="attr_ZfW_reflectimago" min="0" value="0">
 					<div class="talent-cell talent-taw">216</div>
@@ -3297,6 +6734,21 @@
 						<button type="roll" name="roll_z_reptilea" value="@{z_reptilea_action}"> <span>Reptilia Natternnest</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_reptilea_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_reptilea">
 					<input type="number" class="talent-taw" name="attr_ZfW_reptilea" min="0" value="0">
 					<div class="talent-cell talent-taw">217</div>
@@ -3311,6 +6763,21 @@
 						<button type="roll" name="roll_z_respondami" value="@{z_respondami_action}"> <span>Respondami Wahrheitszwang</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_respondami_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_respondami">
 					<input type="number" class="talent-taw" name="attr_ZfW_respondami" min="0" value="0">
 					<div class="talent-cell talent-taw">218</div>
@@ -3325,6 +6792,21 @@
 						<button type="roll" name="roll_z_reversalis" value="@{z_reversalis_action}"> <span>Reversalis Revidum</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_reversalis_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_reversalis">
 					<input type="number" class="talent-taw" name="attr_ZfW_reversalis" min="0" value="0">
 					<div class="talent-cell talent-taw">219</div>
@@ -3339,6 +6821,21 @@
 						<button type="roll" name="roll_z_ruhekoerper" value="@{z_ruhekoerper_action}"> <span>Ruhe Körper, Ruhe Geist</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_ruhe_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ruhe">
 					<input type="number" class="talent-taw" name="attr_ZfW_ruhe" min="0" value="0">
 					<div class="talent-cell talent-taw">220</div>
@@ -3353,6 +6850,21 @@
 						<button type="roll" name="roll_z_salander" value="@{z_salander_action}"> <span>Salander Mutander</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_salander_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_salander">
 					<input type="number" class="talent-taw" name="attr_ZfW_salander" min="0" value="0">
 					<div class="talent-cell talent-taw">221</div>
@@ -3367,6 +6879,21 @@
 						<button type="roll" name="roll_z_sanftmut" value="@{z_sanftmut_action}"> <span>Sanftmut</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Sanftmut_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Sanftmut">
 					<input type="number" class="talent-taw" name="attr_ZfW_Sanftmut" min="0" value="0">
 					<div class="talent-cell talent-taw">222</div>
@@ -3381,6 +6908,21 @@
 						<button type="roll" name="roll_z_sapefacta" value="@{z_sapefacta_action}"> <span>Sapefacta Zauberschwamm</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_sapefacta_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sapefacta">
 					<input type="number" class="talent-taw" name="attr_ZfW_sapefacta" min="0" value="0">
 					<div class="talent-cell talent-taw">223</div>
@@ -3395,6 +6937,21 @@
 						<button type="roll" name="roll_z_satuariasherrlichkeit" value="@{z_satuariasherrlichkeit_action}"> <span>Satuarias Herrlichkeit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_satuarias_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_satuarias">
 					<input type="number" class="talent-taw" name="attr_ZfW_satuarias" min="0" value="0">
 					<div class="talent-cell talent-taw">224</div>
@@ -3409,6 +6966,21 @@
 						<button type="roll" name="roll_z_schabernack" value="@{z_schabernack_action}"> <span>Schabernack</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Schabernack_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schabernack">
 					<input type="number" class="talent-taw" name="attr_ZfW_Schabernack" min="0" value="0">
 					<div class="talent-cell talent-taw">225</div>
@@ -3423,6 +6995,21 @@
 						<button type="roll" name="roll_z_schadenszauberbannen" value="@{z_schadenszauberbannen_action}"> <span>Schadenszauber bannen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_schadenszauber_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_schadenszauber">
 					<input type="number" class="talent-taw" name="attr_ZfW_schadenszauber" min="0" value="0">
 					<div class="talent-cell talent-taw">226</div>
@@ -3437,6 +7024,21 @@
 						<button type="roll" name="roll_z_schelmenkleister" value="@{z_schelmenkleister_action}"> <span>Schelmenkleister</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Schelmenkleister_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schelmenkleister">
 					<input type="number" class="talent-taw" name="attr_ZfW_Schelmenkleister" min="0" value="0">
 					<div class="talent-cell talent-taw">227</div>
@@ -3451,6 +7053,21 @@
 						<button type="roll" name="roll_z_schelmenlaune" value="@{z_schelmenlaune_action}"> <span>Schelmenlaune</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Höchste Magieresistenz + Zahl der Betroffenen + Stärke des Stimmungsumschwungs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Schelmenlaune_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schelmenlaune">
 					<input type="number" class="talent-taw" name="attr_ZfW_Schelmenlaune" min="0" value="0">
 					<div class="talent-cell talent-taw">228</div>
@@ -3465,6 +7082,21 @@
 						<button type="roll" name="roll_z_schelmenmaske" value="@{z_schelmenmaske_action}"> <span>Schelmenmaske</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Schelmenmaske_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schelmenmaske">
 					<input type="number" class="talent-taw" name="attr_ZfW_Schelmenmaske" min="0" value="0">
 					<div class="talent-cell talent-taw">229</div>
@@ -3479,6 +7111,21 @@
 						<button type="roll" name="roll_z_schelmenrausch" value="@{z_schelmenrausch_action}"> <span>Schelmenrausch</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Schelmenrausch_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schelmenrausch">
 					<input type="number" class="talent-taw" name="attr_ZfW_Schelmenrausch" min="0" value="0">
 					<div class="talent-cell talent-taw">230</div>
@@ -3493,6 +7140,21 @@
 						<button type="roll" name="roll_z_dz_schlangenruf" value="@{z_dz_schlangenruf_action}"> <span>Schlangenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Schlangenruf_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Schlangenruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Schlangenruf" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -3507,6 +7169,21 @@
 						<button type="roll" name="roll_z_schleierderunwissenheit" value="@{z_schleierderunwissenheit_action}"> <span>Schleier der Unwissenheit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_schleier_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_schleier">
 					<input type="number" class="talent-taw" name="attr_ZfW_schleier" min="0" value="0">
 					<div class="talent-cell talent-taw">231</div>
@@ -3521,6 +7198,21 @@
 						<button type="roll" name="roll_z_schwarzundrot" value="@{z_schwarzundrot_action}"> <span>Schwarz und Rot</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_schwarzundrot_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_schwarzundrot">
 					<input type="number" class="talent-taw" name="attr_ZfW_schwarzundrot" min="0" value="0">
 					<div class="talent-cell talent-taw">232</div>
@@ -3535,6 +7227,21 @@
 						<button type="roll" name="roll_z_schwarzerschrecken" value="@{z_schwarzerschrecken_action}"> <span>Schwarzer Schrecken</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_schwarzerschrecken_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_schwarzerschrecken">
 					<input type="number" class="talent-taw" name="attr_ZfW_schwarzerschrecken" min="0" value="0">
 					<div class="talent-cell talent-taw">233</div>
@@ -3549,6 +7256,21 @@
 						<button type="roll" name="roll_z_dz_seelenfeuerlichterloh" value="@{z_dz_seelenfeuerlichterloh_action}"> <span>Seelenfeuer Lichterloh</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Seelenfeuer_Lichterloh_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Seelenfeuer_Lichterloh">
 					<input type="number" class="talent-taw" name="attr_ZfW_Seelenfeuer_Lichterloh" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -3563,6 +7285,21 @@
 						<button type="roll" name="roll_z_seelentiererkennen" value="@{z_seelentiererkennen_action}"> <span>Seelentier erkennen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_seelentier_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_seelentier">
 					<input type="number" class="talent-taw" name="attr_ZfW_seelentier" min="0" value="0">
 					<div class="talent-cell talent-taw">234</div>
@@ -3577,6 +7314,21 @@
 						<button type="roll" name="roll_z_seelenwanderung" value="@{z_seelenwanderung_action}"> <span>Seelenwanderung</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Doppelte Magieresistenz, mindestens aber 7">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_seelenwanderung_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_seelenwanderung">
 					<input type="number" class="talent-taw" name="attr_ZfW_seelenwanderung" min="0" value="0">
 					<div class="talent-cell talent-taw">235</div>
@@ -3591,6 +7343,21 @@
 						<button type="roll" name="roll_z_seidenweich" value="@{z_seidenweich_action}"> <span>Seidenweich Schuppengleich</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_seidenweich_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_seidenweich">
 					<input type="number" class="talent-taw" name="attr_ZfW_seidenweich" min="0" value="0">
 					<div class="talent-cell talent-taw">236</div>
@@ -3605,6 +7372,21 @@
 						<button type="roll" name="roll_z_seidenzunge" value="@{z_seidenzunge_action}"> <span>Seidenzunge Elfenwort</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_seidenzunge_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_seidenzunge">
 					<input type="number" class="talent-taw" name="attr_ZfW_seidenzunge" min="0" value="0">
 					<div class="talent-cell talent-taw">237</div>
@@ -3619,6 +7401,21 @@
 						<button type="roll" name="roll_z_sensattacco" value="@{z_sensattacco_action}"> <span>Sensattacco Meisterstreich</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_sensattacco_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sensattacco">
 					<input type="number" class="talent-taw" name="attr_ZfW_sensattacco" min="0" value="0">
 					<div class="talent-cell talent-taw">238</div>
@@ -3633,6 +7430,21 @@
 						<button type="roll" name="roll_z_sensibar" value="@{z_sensibar_action}"> <span>Sensibar Empathicus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_sensibar_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sensibar">
 					<input type="number" class="talent-taw" name="attr_ZfW_sensibar" min="0" value="0">
 					<div class="talent-cell talent-taw">239</div>
@@ -3647,6 +7459,21 @@
 						<button type="roll" name="roll_z_serpentialis" value="@{z_serpentialis_action}"> <span>Serpentialis Schlangenleib</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_serpentialis_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_serpentialis">
 					<input type="number" class="talent-taw" name="attr_ZfW_serpentialis" min="0" value="0">
 					<div class="talent-cell talent-taw">240</div>
@@ -3661,6 +7488,21 @@
 						<button type="roll" name="roll_z_silentium" value="@{z_silentium_action}"> <span>Silentium Schweigekreis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_silentium_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_silentium">
 					<input type="number" class="talent-taw" name="attr_ZfW_silentium" min="0" value="0">
 					<div class="talent-cell talent-taw">241</div>
@@ -3675,6 +7517,21 @@
 						<button type="roll" name="roll_z_sinesigil" value="@{z_sinesigil_action}"> <span>Sinesigil unerkannt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_sinesigil_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sinesigil">
 					<input type="number" class="talent-taw" name="attr_ZfW_sinesigil" min="0" value="0">
 					<div class="talent-cell talent-taw">242</div>
@@ -3689,6 +7546,21 @@
 						<button type="roll" name="roll_z_skelettarius" value="@{z_skelettarius_action}"> <span>Skelettarius Totenherr</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Untoten">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_skelettarius_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_skelettarius">
 					<input type="number" class="talent-taw" name="attr_ZfW_skelettarius" min="0" value="0">
 					<div class="talent-cell talent-taw">243</div>
@@ -3703,6 +7575,21 @@
 						<button type="roll" name="roll_z_solidirid" value="@{z_solidirid_action}"> <span>Solidirid Weg aus Licht</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_solidirid_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_solidirid">
 					<input type="number" class="talent-taw" name="attr_ZfW_solidirid" min="0" value="0">
 					<div class="talent-cell talent-taw">245</div>
@@ -3717,6 +7604,21 @@
 						<button type="roll" name="roll_z_somnigravis" value="@{z_somnigravis_action}"> <span>Somnigravis tiefer Schlaf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_somnigravis_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_somnigravis">
 					<input type="number" class="talent-taw" name="attr_ZfW_somnigravis" min="0" value="0">
 					<div class="talent-cell talent-taw">246</div>
@@ -3731,6 +7633,21 @@
 						<button type="roll" name="roll_z_dz_sphaerovisioschreckensbild" value="@{z_dz_sphaerovisioschreckensbild_action}"> <span>Sphaerovisio Schreckensbild</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Sphaerovisio_Schreckensbild_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Sphaerovisio_Schreckensbild">
 					<input type="number" class="talent-taw" name="attr_ZfW_Sphaerovisio_Schreckensbild" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -3745,6 +7662,21 @@
 						<button type="roll" name="roll_z_spinnenlauf" value="@{z_spinnenlauf_action}"> <span>Spinnenlauf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_spinnenlauf_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_spinnenlauf">
 					<input type="number" class="talent-taw" name="attr_ZfW_spinnenlauf" min="0" value="0">
 					<div class="talent-cell talent-taw">247</div>
@@ -3759,6 +7691,21 @@
 						<button type="roll" name="roll_z_dz_spinnennetz" value="@{z_dz_spinnennetz_action}"> <span>Spinnennetz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Spinnennetz_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Spinnennetz">
 					<input type="number" class="talent-taw" name="attr_ZfW_Spinnennetz" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -3773,6 +7720,21 @@
 						<button type="roll" name="roll_z_dz_spinnenruf" value="@{z_dz_spinnenruf_action}"> <span>Spinnenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Spinnenruf_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Spinnenruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Spinnenruf" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -3787,6 +7749,21 @@
 						<button type="roll" name="roll_z_spurlos" value="@{z_spurlos_action}"> <span>Spurlos Trittlos</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_spurlos_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_spurlos">
 					<input type="number" class="talent-taw" name="attr_ZfW_spurlos" min="0" value="0">
 					<div class="talent-cell talent-taw">248</div>
@@ -3801,6 +7778,21 @@
 						<button type="roll" name="roll_z_standfest" value="@{z_standfest_action}"> <span>Standfest Katzengleich</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_standfest_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_standfest">
 					<input type="number" class="talent-taw" name="attr_ZfW_standfest" min="0" value="0">
 					<div class="talent-cell talent-taw">249</div>
@@ -3815,6 +7807,21 @@
 						<button type="roll" name="roll_z_staubwandle" value="@{z_staubwandle_action}"> <span>Staub wandle!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die handwerkliche Qualität des unbelebten Golemids, das Grundmaterial, die elementare Reinheit des Ausgangsmaterials, der Größe des Golemids, der Eigenschaften des Golemids, die Anzahl weiterer Dienste, die besonderen Fähigkeiten des Golemids und die Talentwerte des Golemids">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_staub_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_staub">
 					<input type="number" class="talent-taw" name="attr_ZfW_staub" min="0" value="0">
 					<div class="talent-cell talent-taw">250</div>
@@ -3829,6 +7836,21 @@
 						<button type="roll" name="roll_z_steinmauer" value="@{z_steinmauer_action}"> <span>Steinmauer</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Steinmauer_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Steinmauer">
 					<input type="number" class="talent-taw" name="attr_ZfW_Steinmauer" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -3843,6 +7865,21 @@
 						<button type="roll" name="roll_z_steinwandle" value="@{z_steinwandle_action}"> <span>Stein wandle!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KK + <span class="abbr" title="Modifikator für die handwerkliche Qualität des unbelebten Golems, das Grundmaterial, die Affinität des Materials zum Erzdämonen, der Größe des Golems, der Eigenschaften des Golems, die Anzahl weiterer Dienste, die besonderen Fähigkeiten des Golems und die Talentwerte des Golems">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_stein_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_stein">
 					<input type="number" class="talent-taw" name="attr_ZfW_stein" min="0" value="0">
 					<div class="talent-cell talent-taw">251</div>
@@ -3857,6 +7894,21 @@
 						<button type="roll" name="roll_z_stillstand" value="@{z_stillstand_action}"> <span>Stillstand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_stillstand_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_stillstand">
 					<input type="number" class="talent-taw" name="attr_ZfW_stillstand" min="0" value="0">
 					<div class="talent-cell talent-taw">252</div>
@@ -3871,6 +7923,21 @@
 						<button type="roll" name="roll_z_stimmendeswindes" value="@{z_stimmendeswindes_action}"> <span>Stimmen des Windes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Stimmen_des_Windes_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Stimmen_des_Windes">
 					<input type="number" class="talent-taw" name="attr_ZfW_Stimmen_des_Windes" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -3885,6 +7952,21 @@
 						<button type="roll" name="roll_z_sumpfstrudel" value="@{z_sumpfstrudel_action}"> <span>Sumpfstrudel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Sumpfstrudel_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Sumpfstrudel">
 					<input type="number" class="talent-taw" name="attr_ZfW_Sumpfstrudel" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -3899,6 +7981,21 @@
 						<button type="roll" name="roll_z_sumuselixiere" value="@{z_sumuselixiere_action}"> <span>Sumus Elixiere</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_sumus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sumus">
 					<input type="number" class="talent-taw" name="attr_ZfW_sumus" min="0" value="0">
 					<div class="talent-cell talent-taw">253</div>
@@ -3913,6 +8010,21 @@
 						<button type="roll" name="roll_z_dz_tanzdererloesung" value="@{z_dz_tanzdererloesung_action}"> <span>Tanz der Erlösung</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Anzahl der wirkenden Sprüche mit den Merkmalen &bdquo;Einfluss&ldquo; oder &bdquo;Herrschaft&ldquo; + Höchste ZfP* der wirkenden Sprüche mit den Merkmalen &bdquo;Einfluss&ldquo; oder &bdquo;Herrschaft&ldquo;">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Tanz_der_Erloesung_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Tanz_der_Erloesung">
 					<input type="number" class="talent-taw" name="attr_ZfW_Tanz_der_Erloesung" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -3927,6 +8039,21 @@
 						<button type="roll" name="roll_z_tauschrausch" value="@{z_tauschrausch_action}"> <span>Tauschrausch</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_tauschrausch_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tauschrausch">
 					<input type="number" class="talent-taw" name="attr_ZfW_tauschrausch" min="0" value="0">
 					<div class="talent-cell talent-taw">254</div>
@@ -3941,6 +8068,21 @@
 						<button type="roll" name="roll_z_tempusstasis" value="@{z_tempusstasis_action}"> <span>Tempus Stasis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK + <span class="abbr" title="1 pro Kampfrunde">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_tempus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tempus">
 					<input type="number" class="talent-taw" name="attr_ZfW_tempus" min="0" value="0">
 					<div class="talent-cell talent-taw">255</div>
@@ -3955,6 +8097,21 @@
 						<button type="roll" name="roll_z_dz_thargunitothbann" value="@{z_dz_thargunitothbann_action}"> <span>Thargunitothbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Thargunitothbann_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Thargunitothbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_Thargunitothbann" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -3969,6 +8126,21 @@
 						<button type="roll" name="roll_z_tierebesprechen" value="@{z_tierebesprechen_action}"> <span>Tiere besprechen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Anzahl zu heilender regeltechnischer Wunden, der Stufe der Krankheit oder der halben Giftstufe">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_tiere_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tiere">
 					<input type="number" class="talent-taw" name="attr_ZfW_tiere" min="0" value="0">
 					<div class="talent-cell talent-taw">256</div>
@@ -3983,6 +8155,21 @@
 						<button type="roll" name="roll_z_tiergedanken" value="@{z_tiergedanken_action}"> <span>Tiergedanken</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_tiergedanken_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tiergedanken">
 					<input type="number" class="talent-taw" name="attr_ZfW_tiergedanken" min="0" value="0">
 					<div class="talent-cell talent-taw">257</div>
@@ -3997,6 +8184,21 @@
 						<button type="roll" name="roll_z_dz_tierruf" value="@{z_dz_tierruf_action}"> <span>Tierruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Tierruf_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Tierruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Tierruf" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -4011,6 +8213,21 @@
 						<button type="roll" name="roll_z_tlalucsodem" value="@{z_tlalucsodem_action}"> <span>Tlalucs Odem Pestgestank</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_tlalucs_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tlalucs">
 					<input type="number" class="talent-taw" name="attr_ZfW_tlalucs" min="0" value="0">
 					<div class="talent-cell talent-taw">258</div>
@@ -4025,6 +8242,21 @@
 						<button type="roll" name="roll_z_toteshandle" value="@{z_toteshandle_action}"> <span>Totes Handle!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Untoten">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_totes_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_totes">
 					<input type="number" class="talent-taw" name="attr_ZfW_totes" min="0" value="0">
 					<div class="talent-cell talent-taw">259</div>
@@ -4039,6 +8271,21 @@
 						<button type="roll" name="roll_z_transformatio" value="@{z_transformatio_action}"> <span>Transformatio Formgestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK + <span class="abbr" title="Modifikator für die Veränderung der Materialqualität, die Veränderungen von Volumen oder Masse und der Veränderung von Form und Struktur">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_transformatio_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_transformatio">
 					<input type="number" class="talent-taw" name="attr_ZfW_transformatio" min="0" value="0">
 					<div class="talent-cell talent-taw">260</div>
@@ -4053,6 +8300,21 @@
 						<button type="roll" name="roll_z_transmutare" value="@{z_transmutare_action}"> <span>Transmutare Körperform</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/GE/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_transmutare_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_transmutare">
 					<input type="number" class="talent-taw" name="attr_ZfW_transmutare" min="0" value="0">
 					<div class="talent-cell talent-taw">261</div>
@@ -4067,6 +8329,21 @@
 						<button type="roll" name="roll_z_transversalis" value="@{z_transversalis_action}"> <span>Transversalis Teleport</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_transversalis_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_transversalis">
 					<input type="number" class="talent-taw" name="attr_ZfW_transversalis" min="0" value="0">
 					<div class="talent-cell talent-taw">262</div>
@@ -4081,6 +8358,21 @@
 						<button type="roll" name="roll_z_traumgestalt" value="@{z_traumgestalt_action}"> <span>Traumgestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Traumgestalt_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Traumgestalt">
 					<input type="number" class="talent-taw" name="attr_ZfW_Traumgestalt" min="0" value="0">
 					<div class="talent-cell talent-taw">263</div>
@@ -4095,6 +8387,21 @@
 						<button type="roll" name="roll_z_umbraporta" value="@{z_umbraporta_action}"> <span>Umbraporta Schattentür</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Umbraporta_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Umbraporta">
 					<input type="number" class="talent-taw" name="attr_ZfW_Umbraporta" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -4109,6 +8416,21 @@
 						<button type="roll" name="roll_z_unberuehrt" value="@{z_unberuehrt_action}"> <span>Unberührt von Satinav</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO + <span class="abbr" title="1 pro Tag Wirkungsdauer über den ersten hinaus">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_unberuhrt_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_unberuhrt">
 					<input type="number" class="talent-taw" name="attr_ZfW_unberuhrt" min="0" value="0">
 					<div class="talent-cell talent-taw">264</div>
@@ -4123,6 +8445,21 @@
 						<button type="roll" name="roll_z_unitatio" value="@{z_unitatio_action}"> <span>Unitatio Geistesbund</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_unitatio_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_unitatio">
 					<input type="number" class="talent-taw" name="attr_ZfW_unitatio" min="0" value="0">
 					<div class="talent-cell talent-taw">265</div>
@@ -4137,6 +8474,21 @@
 						<button type="roll" name="roll_z_dz_unsichtbareglut" value="@{z_dz_unsichtbareglut_action}"> <span>Unsichtbare Glut</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Unsichtbare_Glut_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Unsichtbare_Glut">
 					<input type="number" class="talent-taw" name="attr_ZfW_Unsichtbare_Glut" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -4151,6 +8503,21 @@
 						<button type="roll" name="roll_z_unsichtbarerjaeger" value="@{z_unsichtbarerjaeger_action}"> <span>Unsichtbarer Jäger</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_unsichtbarer_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_unsichtbarer">
 					<input type="number" class="talent-taw" name="attr_ZfW_unsichtbarer" min="0" value="0">
 					<div class="talent-cell talent-taw">266</div>
@@ -4165,6 +8532,21 @@
 						<button type="roll" name="roll_z_dz_valetudolebenskraft" value="@{z_dz_valetudolebenskraft_action}"> <span>Valetudo Lebenskraft</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Valetudo_Lebenskraft_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Valetudo_Lebenskraft">
 					<input type="number" class="talent-taw" name="attr_ZfW_Valetudo_Lebenskraft" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -4179,6 +8561,21 @@
 						<button type="roll" name="roll_z_veraenderungaufheben" value="@{z_veraenderungaufheben_action}"> <span>Veränderung aufheben</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_veranderung_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_veranderung">
 					<input type="number" class="talent-taw" name="attr_ZfW_veranderung" min="0" value="0">
 					<div class="talent-cell talent-taw">267</div>
@@ -4193,6 +8590,21 @@
 						<button type="roll" name="roll_z_verschwindibus" value="@{z_verschwindibus_action}"> <span>Verschwindibus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_verschwindibus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_verschwindibus">
 					<input type="number" class="talent-taw" name="attr_ZfW_verschwindibus" min="0" value="0">
 					<div class="talent-cell talent-taw">268</div>
@@ -4207,6 +8619,21 @@
 						<button type="roll" name="roll_z_verstaendigungstoeren" value="@{z_verstaendigungstoeren_action}"> <span>Verständigung stören</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_verstandigung_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_verstandigung">
 					<input type="number" class="talent-taw" name="attr_ZfW_verstandigung" min="0" value="0">
 					<div class="talent-cell talent-taw">269</div>
@@ -4221,6 +8648,21 @@
 						<button type="roll" name="roll_z_verwandlungbeenden" value="@{z_verwandlungbeenden_action}"> <span>Verwandlung beenden</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_verwandlung_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_verwandlung">
 					<input type="number" class="talent-taw" name="attr_ZfW_verwandlung" min="0" value="0">
 					<div class="talent-cell talent-taw">270</div>
@@ -4235,6 +8677,21 @@
 						<button type="roll" name="roll_z_vipernblick" value="@{z_vipernblick_action}"> <span>Vipernblick</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_vipernblick_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_vipernblick">
 					<input type="number" class="talent-taw" name="attr_ZfW_vipernblick" min="0" value="0">
 					<div class="talent-cell talent-taw">271</div>
@@ -4249,6 +8706,21 @@
 						<button type="roll" name="roll_z_visibili" value="@{z_visibili_action}"> <span>Visibili Vanitar</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_visibili_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_visibili">
 					<input type="number" class="talent-taw" name="attr_ZfW_visibili" min="0" value="0">
 					<div class="talent-cell talent-taw">272</div>
@@ -4263,6 +8735,21 @@
 						<button type="roll" name="roll_z_vocolimbo" value="@{z_vocolimbo_action}"> <span>Vocolimbo Hohler Klang</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_vocolimbo_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_vocolimbo">
 					<input type="number" class="talent-taw" name="attr_ZfW_vocolimbo" min="0" value="0">
 					<div class="talent-cell talent-taw">273</div>
@@ -4277,6 +8764,21 @@
 						<button type="roll" name="roll_z_vogelzwitschern" value="@{z_vogelzwitschern_action}"> <span>Vogelzwitschern Glockenspiel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_vogelzwitschern_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_vogelzwitschern">
 					<input type="number" class="talent-taw" name="attr_ZfW_vogelzwitschern" min="0" value="0">
 					<div class="talent-cell talent-taw">274</div>
@@ -4291,6 +8793,21 @@
 						<button type="roll" name="roll_z_wandausdornen" value="@{z_wandausdornen_action}"> <span>Wand aus Dornen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_wandausdornen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_wandausdornen">
 					<input type="number" class="talent-taw" name="attr_ZfW_wandausdornen" min="0" value="0">
 					<div class="talent-cell talent-taw">275</div>
@@ -4305,6 +8822,21 @@
 						<button type="roll" name="roll_z_wandausflammen" value="@{z_wandausflammen_action}"> <span>Wand aus Flammen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Wand_aus_Flammen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Wand_aus_Flammen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Wand_aus_Flammen" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -4319,6 +8851,21 @@
 						<button type="roll" name="roll_z_warmesblut" value="@{z_warmesblut_action}"> <span>Warmes Blut</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_warmes_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_warmes">
 					<input type="number" class="talent-taw" name="attr_ZfW_warmes" min="0" value="0">
 					<div class="talent-cell talent-taw">276</div>
@@ -4333,6 +8880,21 @@
 						<button type="roll" name="roll_z_warmesgefriere" value="@{z_warmesgefriere_action}"> <span>Warmes gefriere</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Warmes_gefriere_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Warmes_gefriere">
 					<input type="number" class="talent-taw" name="attr_ZfW_Warmes_gefriere" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -4347,6 +8909,21 @@
 						<button type="roll" name="roll_z_wasseratem" value="@{z_wasseratem_action}"> <span>Wasseratem</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_wasseratem_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_wasseratem">
 					<input type="number" class="talent-taw" name="attr_ZfW_wasseratem" min="0" value="0">
 					<div class="talent-cell talent-taw">277</div>
@@ -4361,6 +8938,21 @@
 						<button type="roll" name="roll_z_wasserwall" value="@{z_wasserwall_action}"> <span>Wasserwall</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Wasserwall_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Wasserwall">
 					<input type="number" class="talent-taw" name="attr_ZfW_Wasserwall" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -4375,6 +8967,21 @@
 						<button type="roll" name="roll_z_weicheserstarre" value="@{z_weicheserstarre_action}"> <span>Weiches erstarre!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_weiches_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_weiches">
 					<input type="number" class="talent-taw" name="attr_ZfW_weiches" min="0" value="0">
 					<div class="talent-cell talent-taw">278</div>
@@ -4389,6 +8996,21 @@
 						<button type="roll" name="roll_z_weihrauchwolke" value="@{z_weihrauchwolke_action}"> <span>Weihrauchwolke Wohlgeruch</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_weihrauchwolke_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_weihrauchwolke">
 					<input type="number" class="talent-taw" name="attr_ZfW_weihrauchwolke" min="0" value="0">
 					<div class="talent-cell talent-taw">279</div>
@@ -4403,6 +9025,21 @@
 						<button type="roll" name="roll_z_weisheitderbaeume" value="@{z_weisheitderbaeume_action}"> <span>Weisheit der Bäume</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="1 pro Woche Wirkungsdauer">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_weisheit_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_weisheit">
 					<input type="number" class="talent-taw" name="attr_ZfW_weisheit" min="0" value="0">
 					<div class="talent-cell talent-taw">280</div>
@@ -4417,6 +9054,21 @@
 						<button type="roll" name="roll_z_dz_weisheitdersteine" value="@{z_dz_weisheitdersteine_action}"> <span>Weisheit der Steine</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="1 pro Woche Wirkungsdauer">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Weisheit_der_Steine_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Weisheit_der_Steine">
 					<input type="number" class="talent-taw" name="attr_ZfW_Weisheit_der_Steine" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -4431,6 +9083,21 @@
 						<button type="roll" name="roll_z_weissemaehn" value="@{z_weissemaehn_action}"> <span>Weiße Mähn' und gold'ner Huf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_weisse_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_weisse">
 					<input type="number" class="talent-taw" name="attr_ZfW_weisse" min="0" value="0">
 					<div class="talent-cell talent-taw">281</div>
@@ -4445,6 +9112,21 @@
 						<button type="roll" name="roll_z_wellenlauf" value="@{z_wellenlauf_action}"> <span>Wellenlauf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/GE/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_wellenlauf_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_wellenlauf">
 					<input type="number" class="talent-taw" name="attr_ZfW_wellenlauf" min="0" value="0">
 					<div class="talent-cell talent-taw">282</div>
@@ -4459,6 +9141,21 @@
 						<button type="roll" name="roll_z_wettermeisterschaft" value="@{z_wettermeisterschaft_action}"> <span>Wettermeisterschaft</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/GE + <span class="abbr" title="Modifikator für die Stärke der Wetteränderung">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_wettermeisterschaft_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_wettermeisterschaft">
 					<input type="number" class="talent-taw" name="attr_ZfW_wettermeisterschaft" min="0" value="0">
 					<div class="talent-cell talent-taw">283</div>
@@ -4473,6 +9170,21 @@
 						<button type="roll" name="roll_z_widerwille" value="@{z_widerwille_action}"> <span>Widerwille Ungemach</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_widerwille_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_widerwille">
 					<input type="number" class="talent-taw" name="attr_ZfW_widerwille" min="0" value="0">
 					<div class="talent-cell talent-taw">285</div>
@@ -4487,6 +9199,21 @@
 						<button type="roll" name="roll_z_windbarriere" value="@{z_windbarriere_action}"> <span>Windbarriere</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Windbarriere_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Windbarriere">
 					<input type="number" class="talent-taw" name="attr_ZfW_Windbarriere" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -4501,6 +9228,21 @@
 						<button type="roll" name="roll_z_windgefluester" value="@{z_windgefluester_action}"> <span>Windgeflüster</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Windgefluester_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Windgefluester">
 					<input type="number" class="talent-taw" name="attr_ZfW_Windgefluester" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -4515,6 +9257,21 @@
 						<button type="roll" name="roll_z_windhose" value="@{z_windhose_action}"> <span>Windhose</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Windhose_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Windhose">
 					<input type="number" class="talent-taw" name="attr_ZfW_Windhose" min="0" value="0">
 					<div class="talent-cell talent-taw">286</div>
@@ -4529,6 +9286,21 @@
 						<button type="roll" name="roll_z_windstille" value="@{z_windstille_action}"> <span>Windstille</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KK + <span class="abbr" title="Modifikator für die vorherrschende Windstärke">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Windstille_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Windstille">
 					<input type="number" class="talent-taw" name="attr_ZfW_Windstille" min="0" value="0">
 					<div class="talent-cell talent-taw">287</div>
@@ -4543,6 +9315,21 @@
 						<button type="roll" name="roll_z_wipfellauf" value="@{z_wipfellauf_action}"> <span>Wipfellauf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Wipfellauf_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Wipfellauf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Wipfellauf" min="0" value="0">
 					<div class="talent-cell talent-taw">288</div>
@@ -4557,6 +9344,21 @@
 						<button type="roll" name="roll_z_xenographus" value="@{z_xenographus_action}"> <span>Xenographus Schriftenkunde</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_xenographus_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_xenographus">
 					<input type="number" class="talent-taw" name="attr_ZfW_xenographus" min="0" value="0">
 					<div class="talent-cell talent-taw">289</div>
@@ -4571,6 +9373,21 @@
 						<button type="roll" name="roll_z_zagibu" value="@{z_zagibu_action}"> <span>Zagibu Ubigaz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zagibu_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zagibu">
 					<input type="number" class="talent-taw" name="attr_ZfW_zagibu" min="0" value="0">
 					<div class="talent-cell talent-taw">290</div>
@@ -4585,6 +9402,21 @@
 						<button type="roll" name="roll_z_zappenduster" value="@{z_zappenduster_action}"> <span>Zappenduster</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Zappenduster_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Zappenduster">
 					<input type="number" class="talent-taw" name="attr_ZfW_Zappenduster" min="0" value="0">
 					<div class="talent-cell talent-taw">291</div>
@@ -4599,6 +9431,21 @@
 						<button type="roll" name="roll_z_zauberklinge" value="@{z_zauberklinge_action}"> <span>Zauberklinge Geisterspeer</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zauberklinge_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zauberklinge">
 					<input type="number" class="talent-taw" name="attr_ZfW_zauberklinge" min="0" value="0">
 					<div class="talent-cell talent-taw">292</div>
@@ -4613,6 +9460,21 @@
 						<button type="roll" name="roll_z_zaubernahrung" value="@{z_zaubernahrung_action}"> <span>Zaubernahrung Hungerbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/KO + <span class="abbr" title="Modifikator für die Anzahl Tage ohne Nahrung und die Anzahl fehlender Lebenspunkte">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zaubernahrung_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zaubernahrung">
 					<input type="number" class="talent-taw" name="attr_ZfW_zaubernahrung" min="0" value="0">
 					<div class="talent-cell talent-taw">293</div>
@@ -4627,6 +9489,21 @@
 						<button type="roll" name="roll_z_zauberwesen" value="@{z_zauberwesen_action}"> <span>Zauberwesen der Natur</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zauberwesen_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zauberwesen">
 					<input type="number" class="talent-taw" name="attr_ZfW_zauberwesen" min="0" value="0">
 					<div class="talent-cell talent-taw">294</div>
@@ -4641,6 +9518,21 @@
 						<button type="roll" name="roll_z_zauberzwang" value="@{z_zauberzwang_action}"> <span>Zauberzwang</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zauberzwang_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zauberzwang">
 					<input type="number" class="talent-taw" name="attr_ZfW_zauberzwang" min="0" value="0">
 					<div class="talent-cell talent-taw">295</div>
@@ -4655,6 +9547,21 @@
 						<button type="roll" name="roll_z_zornderelemente" value="@{z_zornderelemente_action}"> <span>Zorn der Elemente</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Elementspezialisierung">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zorn_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zorn">
 					<input type="number" class="talent-taw" name="attr_ZfW_zorn" min="0" value="0">
 					<div class="talent-cell talent-taw">296</div>
@@ -4669,6 +9576,21 @@
 						<button type="roll" name="roll_z_zungelaehmen" value="@{z_zungelaehmen_action}"> <span>Zunge lähmen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zunge_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zunge">
 					<input type="number" class="talent-taw" name="attr_ZfW_zunge" min="0" value="0">
 					<div class="talent-cell talent-taw">297</div>
@@ -4683,6 +9605,21 @@
 						<button type="roll" name="roll_z_zwingtanz" value="@{z_zwingtanz_action}"> <span>Zwingtanz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Zwingtanz_rep">
+							<option value="">---</option>
+							<option value="Mag">gildenmagisch</option>
+							<option value="Elf">elfisch</option>
+							<option value="Dru">druidisch</option>
+							<option value="Sat">satuarisch</option>
+							<option value="Geo">geodisch</option>
+							<option value="Sch">schelmisch</option>
+							<option value="Srl">scharlatanisch</option>
+							<option value="Bor">borbaradianisch</option>
+							<option value="Ach">kristallomantisch</option>
+							<option value="Kop">kophtanisch</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Zwingtanz">
 					<input type="number" class="talent-taw" name="attr_ZfW_Zwingtanz" min="0" value="0">
 					<div class="talent-cell talent-taw">298</div>

--- a/Das_Schwarze_Auge_4-1/dev/html/sheet/section_magie.html
+++ b/Das_Schwarze_Auge_4-1/dev/html/sheet/section_magie.html
@@ -23,7 +23,7 @@
 		</table>
 		<br>
 		<div class="section section-Zauberbogen" align="center">
-			<b>Repräsentation</b>
+			<b>Erstrepräsentation</b>
 			<select type="text" name="attr_z_erstrepraesentation" style="width: 12em;">
 				<option value="">---</option>
 				<option value="Mag">gildenmagisch</option>
@@ -54,7 +54,7 @@
 				<div style="display:inline-block">
 					<div class="talent-cell talent-name talent-head">Zauber</div>
 					<div class="talent-cell talent-eigenschaften talent-head">Eigenschaften</div>
-					<div class="talent-cell talent-rep talent-head">Repräsentation</div>
+					<div class="talent-cell talent-rep talent-head" title="Repräsentation ('---' verwendet Erstrepräsentation)">Rep.</div>
 					<div class="talent-cell talent-spez talent-head">Spezialisierung</div>
 					<div class="talent-cell talent-taw talent-head">ZfW</div>
 					<div class="talent-cell talent-taw talent-head">Seite</div>
@@ -71,16 +71,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_abvenenum_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_abvenenum">
@@ -100,16 +100,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_accuratum_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_accuratum">
@@ -129,16 +129,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Adamantium_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Adamantium">
@@ -158,16 +158,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Adlerauge_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Adlerauge">
@@ -187,16 +187,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Adlerschwinge_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Adlerschwinge">
@@ -216,16 +216,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Aeolitus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aeolitus">
@@ -245,16 +245,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Aerofugo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aerofugo">
@@ -274,16 +274,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Aerogelo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aerogelo">
@@ -303,16 +303,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Aeropulvis_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aeropulvis">
@@ -332,16 +332,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Agrimothbann_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Agrimothbann">
@@ -361,16 +361,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Alpgestalt_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Alpgestalt">
@@ -390,16 +390,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Analys_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Analys">
@@ -419,16 +419,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_angste_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_angste">
@@ -446,18 +446,18 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Animato_rep">
+						<select type="text" name="attr_z_Animatio_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Animato">
@@ -477,16 +477,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Applicatus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Applicatus">
@@ -506,16 +506,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Aquafaxius_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aquafaxius">
@@ -535,16 +535,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Aquaqueris_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aquaqueris">
@@ -564,16 +564,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Aquasphaero_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aquasphaero">
@@ -593,16 +593,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Arachnea_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Arachnea">
@@ -622,16 +622,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Arcanovi_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Arcanovi">
@@ -651,16 +651,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Archofaxius_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Archofaxius">
@@ -680,16 +680,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Archosphaero_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Archosphaero">
@@ -709,16 +709,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Armatrutz_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Armatrutz">
@@ -738,16 +738,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Atemnot_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Atemnot">
@@ -775,6 +775,21 @@
 							<option value="@{KK}">KK</option>
 						</select>
 					</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_attributo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Attributo">
 					<input type="number" class="talent-taw" name="attr_ZfW_Attributo" min="0" value="0">
 					<div class="talent-cell talent-taw">30</div>
@@ -792,16 +807,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Aufgeblasen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aufgeblasen">
@@ -821,16 +836,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Auge_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Auge">
@@ -850,16 +865,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Aureolus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aureolus">
@@ -879,16 +894,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Auris_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Auris">
@@ -908,16 +923,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Axxeleratus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Axxeleratus">
@@ -937,16 +952,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Balsam_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Balsam">
@@ -966,16 +981,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_band_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_band">
@@ -995,16 +1010,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Bannbaladin_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Bannbaladin">
@@ -1024,16 +1039,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Barenruhe_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Barenruhe">
@@ -1053,16 +1068,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Beherrschung_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Beherrschung">
@@ -1082,16 +1097,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Belzhorashbann_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Belzhorashbann">
@@ -1111,16 +1126,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Beschworung_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Beschworung">
@@ -1140,16 +1155,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Bewegung_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Bewegung">
@@ -1169,16 +1184,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Bienenschwarm_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Bienenschwarm">
@@ -1198,16 +1213,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Blendwerk_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Blendwerk">
@@ -1227,16 +1242,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_blickaufswesen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_blickaufswesen">
@@ -1256,16 +1271,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_blickdurchfremdeaugen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_blickdurchfremdeaugen">
@@ -1285,16 +1300,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_blickindiegedanken_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_blickindiegedanken">
@@ -1314,16 +1329,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_blickindievergangenheit_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_blickindievergangenheit">
@@ -1343,16 +1358,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Blitz_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Blitz">
@@ -1372,16 +1387,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_boser_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_boser">
@@ -1401,16 +1416,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_brenne_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_brenne">
@@ -1430,16 +1445,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_caldofrigo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_caldofrigo">
@@ -1459,16 +1474,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_chamaelioni_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_chamaelioni">
@@ -1488,16 +1503,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_chimaeroform_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_chimaeroform">
@@ -1517,16 +1532,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_chronoklassis_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_chronoklassis">
@@ -1546,16 +1561,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_chrononautos_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_chrononautos">
@@ -1575,16 +1590,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_claudibus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_claudibus">
@@ -1604,16 +1619,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_corpofesso_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_corpofesso">
@@ -1633,16 +1648,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_corpofrigo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_corpofrigo">
@@ -1662,16 +1677,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_cryptographo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_cryptographo">
@@ -1691,16 +1706,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_custodosigil_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_custodosigil">
@@ -1720,16 +1735,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_damonenbann_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_damonenbann">
@@ -1749,16 +1764,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_delicioso_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_delicioso">
@@ -1778,16 +1793,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_desintegratus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_desintegratus">
@@ -1807,16 +1822,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_destructibo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_destructibo">
@@ -1836,16 +1851,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dichter_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dichter">
@@ -1865,16 +1880,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Dschinnenruf_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Dschinnenruf">
@@ -1894,16 +1909,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Dunkelheit_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Dunkelheit">
@@ -1923,16 +1938,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_duplicatus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_duplicatus">
@@ -1952,16 +1967,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_ecliptifactus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ecliptifactus">
@@ -1981,16 +1996,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_eigenschaft_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eigenschaft">
@@ -2010,16 +2025,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_eigne_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eigne">
@@ -2039,16 +2054,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_einfluss_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_einfluss">
@@ -2068,16 +2083,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_eins_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eins">
@@ -2097,16 +2112,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_eisenrost_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eisenrost">
@@ -2126,16 +2141,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_eiseskalte_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eiseskalte">
@@ -2155,16 +2170,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Eiswirbel_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Eiswirbel">
@@ -2184,16 +2199,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Elementarbann_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Elementarbann">
@@ -2213,16 +2228,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_elementarer_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_elementarer">
@@ -2242,16 +2257,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_elfenstimme_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_elfenstimme">
@@ -2271,16 +2286,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Entfesselung_des_Getiers_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Entfesselung_des_Getiers">
@@ -2300,16 +2315,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_erinnerung_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_erinnerung">
@@ -2329,16 +2344,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_exposami_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_exposami">
@@ -2358,16 +2373,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_falkenauge_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_falkenauge">
@@ -2387,16 +2402,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_favilludo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_favilludo">
@@ -2416,16 +2431,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Fesselranken_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Fesselranken">
@@ -2445,16 +2460,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Feuermaehne_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Feuermaehne">
@@ -2474,16 +2489,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Feuersturm_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Feuersturm">
@@ -2503,16 +2518,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Firnlauf_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Firnlauf">
@@ -2532,16 +2547,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_flim_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_flim">
@@ -2561,16 +2576,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_fluch_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_fluch">
@@ -2590,16 +2605,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_foramen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_foramen">
@@ -2619,16 +2634,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_fortifex_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_fortifex">
@@ -2648,16 +2663,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Frigifaxius_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Frigifaxius">
@@ -2677,16 +2692,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Frigisphaero_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Frigisphaero">
@@ -2706,16 +2721,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_fulminictus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_fulminictus">
@@ -2735,16 +2750,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_gardianum_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_gardianum">
@@ -2764,16 +2779,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Gebieter_der_Tiefe_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Gebieter_der_Tiefe">
@@ -2793,16 +2808,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_gedankenbilder_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_gedankenbilder">
@@ -2822,16 +2837,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_gefass_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_gefass">
@@ -2851,16 +2866,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_gefunden_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_gefunden">
@@ -2880,16 +2895,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Geisterbann_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Geisterbann">
@@ -2909,16 +2924,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Geisterruf_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Geisterruf">
@@ -2938,16 +2953,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Geschoss_der_Niederhoellen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Geschoss_der_Niederhoellen">
@@ -2967,16 +2982,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Glacoflumen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Glacoflumen">
@@ -2996,16 +3011,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Gletscherwand_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Gletscherwand">
@@ -3025,16 +3040,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_granit_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_granit">
@@ -3054,16 +3069,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Grolmenseele_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Grolmenseele">
@@ -3083,16 +3098,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_grossegier_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_grossegier">
@@ -3112,16 +3127,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_grosseverwirrung_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_grosseverwirrung">
@@ -3141,16 +3156,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Halluzination_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Halluzination">
@@ -3170,16 +3185,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Harmlose_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Harmlose">
@@ -3199,16 +3214,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_hartes_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_hartes">
@@ -3228,16 +3243,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_haselbusch_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_haselbusch">
@@ -3257,16 +3272,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Hauch_der_Tiefen_Tochter_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Hauch_der_Tiefen_Tochter">
@@ -3286,16 +3301,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_heilkraft_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_heilkraft">
@@ -3315,16 +3330,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_hellsicht_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_hellsicht">
@@ -3344,16 +3359,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_herbeirufung_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_herbeirufung">
@@ -3373,16 +3388,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_herr_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_herr">
@@ -3402,16 +3417,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_herzschlag_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_herzschlag">
@@ -3431,16 +3446,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Hexagramma_Dschinnenbann_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Hexagramma_Dschinnenbann">
@@ -3460,16 +3475,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Hexenblick_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenblick">
@@ -3489,16 +3504,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Hexengalle_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexengalle">
@@ -3518,16 +3533,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Hexenholz_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenholz">
@@ -3547,16 +3562,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Hexenknoten_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenknoten">
@@ -3576,16 +3591,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Hexenkrallen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenkrallen">
@@ -3605,16 +3620,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Hexenspeichel_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenspeichel">
@@ -3634,16 +3649,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_hilfreiche_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_hilfreiche">
@@ -3663,16 +3678,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_hollenpein_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_hollenpein">
@@ -3692,16 +3707,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Holterdipolter_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Holterdipolter">
@@ -3721,16 +3736,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Hornissenruf_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Hornissenruf">
@@ -3750,16 +3765,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_horriphobus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_horriphobus">
@@ -3779,16 +3794,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Humofaxius_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Humofaxius">
@@ -3808,16 +3823,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Humosphaero_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Humosphaero">
@@ -3837,16 +3852,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_ignifaxius_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ignifaxius">
@@ -3866,16 +3881,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Igniflumen_Flammenspur_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Igniflumen_Flammenspur">
@@ -3895,16 +3910,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Ignifugo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Ignifugo">
@@ -3924,16 +3939,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Ignimorpho_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Ignimorpho">
@@ -3953,16 +3968,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Igniplano_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Igniplano">
@@ -3982,16 +3997,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Igniqueris_Feuerkragen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Igniqueris_Feuerkragen">
@@ -4011,16 +4026,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_ignisphaero_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ignisphaero">
@@ -4040,16 +4055,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_ignorantia_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ignorantia">
@@ -4069,16 +4084,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_illusion_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_illusion">
@@ -4098,16 +4113,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_immortalis_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_immortalis">
@@ -4127,16 +4142,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_imperavi_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_imperavi">
@@ -4156,16 +4171,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_impersona_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_impersona">
@@ -4185,16 +4200,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_infinitum_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_infinitum">
@@ -4214,16 +4229,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_invercano_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_invercano">
@@ -4243,16 +4258,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_invocatiomaior_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_invocatiomaior">
@@ -4272,16 +4287,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_invocatiominor_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_invocatiominor">
@@ -4301,16 +4316,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_iribaars_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_iribaars">
@@ -4330,16 +4345,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_juckreiz_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_juckreiz">
@@ -4359,16 +4374,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_karnifilo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_karnifilo">
@@ -4388,16 +4403,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Katzenaugen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Katzenaugen">
@@ -4417,16 +4432,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_klarum_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_klarum">
@@ -4446,16 +4461,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Klickeradomms_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Klickeradomms">
@@ -4475,16 +4490,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Koboldgeschenk_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Koboldgeschenk">
@@ -4504,16 +4519,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Koboldovision_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Koboldovision">
@@ -4533,16 +4548,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_komm_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_komm">
@@ -4562,16 +4577,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_koerperlose_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_koerperlose">
@@ -4591,16 +4606,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_krabbelnder_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_krabbelnder">
@@ -4620,16 +4635,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_kraft_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_kraft">
@@ -4649,16 +4664,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_kraft_humus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_kraft_humus">
@@ -4678,16 +4693,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_krahenruf_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_krahenruf">
@@ -4707,16 +4722,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_krotensprung_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_krotensprung">
@@ -4736,16 +4751,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_kulminatio_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_kulminatio">
@@ -4765,16 +4780,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_kusch_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_kusch">
@@ -4794,16 +4809,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_lach_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_lach">
@@ -4823,16 +4838,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Lachkrampf_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Lachkrampf">
@@ -4852,16 +4867,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_langer_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_langer">
@@ -4881,16 +4896,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_last_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_last">
@@ -4910,16 +4925,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Leib_aus_tausend_Fliegen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Leib_aus_tausend_Fliegen">
@@ -4939,16 +4954,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_leibdererde_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdererde">
@@ -4968,16 +4983,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_leibderwogen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibderwogen">
@@ -4997,16 +5012,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_leibdeseises_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdeseises">
@@ -5026,16 +5041,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_leibdeserzes_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdeserzes">
@@ -5055,16 +5070,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_leibdesfeuers_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdesfeuers">
@@ -5084,16 +5099,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_leibdeswindes_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdeswindes">
@@ -5113,16 +5128,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Leidensbund_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Leidensbund">
@@ -5142,16 +5157,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_levthans_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_levthans">
@@ -5171,16 +5186,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_limbus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_limbus">
@@ -5200,16 +5215,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_lockruf_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_lockruf">
@@ -5229,16 +5244,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_lunge_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_lunge">
@@ -5258,16 +5273,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_madas_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_madas">
@@ -5287,16 +5302,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_magischer_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_magischer">
@@ -5316,16 +5331,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Mahlstrom_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Mahlstrom">
@@ -5345,16 +5360,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Malmkreis_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Malmkreis">
@@ -5374,16 +5389,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_manifesto_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_manifesto">
@@ -5403,16 +5418,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_meisterderelemente_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_meisterderelemente">
@@ -5432,16 +5447,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_meisterminderergeister_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_meisterminderergeister">
@@ -5461,16 +5476,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_memorabia_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_memorabia">
@@ -5490,16 +5505,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_memorans_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_memorans">
@@ -5519,16 +5534,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_menetekel_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_menetekel">
@@ -5548,16 +5563,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_metamagie_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_metamagie">
@@ -5577,16 +5592,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_metamorpho_felsenform_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_metamorpho_felsenform">
@@ -5606,16 +5621,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_metamorpho_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_metamorpho">
@@ -5635,16 +5650,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_motoricus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_motoricus">
@@ -5664,16 +5679,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_movimento_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_movimento">
@@ -5693,16 +5708,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_murks_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_murks">
@@ -5722,16 +5737,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Nackedei_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Nackedei">
@@ -5751,16 +5766,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Nebelleib_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Nebelleib">
@@ -5780,16 +5795,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_nebelwand_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_nebelwand">
@@ -5809,16 +5824,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_nekropathia_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_nekropathia">
@@ -5838,16 +5853,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_nihilogravo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_nihilogravo">
@@ -5867,16 +5882,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_nuntiovolo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_nuntiovolo">
@@ -5896,16 +5911,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_objecto_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_objecto">
@@ -5925,16 +5940,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Objectofixo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Objectofixo">
@@ -5954,16 +5969,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_objectovoco_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_objectovoco">
@@ -5983,16 +5998,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_objekt_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_objekt">
@@ -6012,16 +6027,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_oculus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_oculus">
@@ -6041,16 +6056,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_odem_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_odem">
@@ -6070,16 +6085,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Orcanofaxius_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Orcanofaxius">
@@ -6099,16 +6114,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Orcanosphaero_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Orcanosphaero">
@@ -6128,16 +6143,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Pandaemonium_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Pandaemonium">
@@ -6157,16 +6172,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_panik_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_panik">
@@ -6186,16 +6201,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Papperlapapp_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Papperlapapp">
@@ -6215,16 +6230,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_paralys_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_paralys">
@@ -6244,16 +6259,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_pectetondo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pectetondo">
@@ -6273,16 +6288,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_penetrizzel_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_penetrizzel">
@@ -6302,16 +6317,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_pentagramma_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pentagramma">
@@ -6331,16 +6346,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_pestilenz_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pestilenz">
@@ -6360,16 +6375,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_pfeilderluft_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeilderluft">
@@ -6389,16 +6404,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_pfeildeseises_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildeseises">
@@ -6418,16 +6433,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_pfeildeserzes_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildeserzes">
@@ -6447,16 +6462,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_pfeildesfeuers_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildesfeuers">
@@ -6476,16 +6491,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_pfeildeshumus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildeshumus">
@@ -6505,16 +6520,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_pfeildeswassers_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildeswassers">
@@ -6534,16 +6549,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_planastrale_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_planastrale">
@@ -6563,16 +6578,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_plumbumbarum_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_plumbumbarum">
@@ -6592,16 +6607,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_projektimago_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_projektimago">
@@ -6621,16 +6636,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_protectionis_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_protectionis">
@@ -6650,16 +6665,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_psychostabilis_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_psychostabilis">
@@ -6679,16 +6694,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_radau_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_radau">
@@ -6708,16 +6723,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_reflectimago_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_reflectimago">
@@ -6737,16 +6752,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_reptilea_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_reptilea">
@@ -6766,16 +6781,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_respondami_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_respondami">
@@ -6795,16 +6810,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_reversalis_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_reversalis">
@@ -6824,16 +6839,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_ruhe_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ruhe">
@@ -6853,16 +6868,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_salander_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_salander">
@@ -6882,16 +6897,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Sanftmut_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Sanftmut">
@@ -6911,16 +6926,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_sapefacta_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sapefacta">
@@ -6940,16 +6955,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_satuarias_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_satuarias">
@@ -6969,16 +6984,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Schabernack_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schabernack">
@@ -6998,16 +7013,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_schadenszauber_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_schadenszauber">
@@ -7027,16 +7042,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Schelmenkleister_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schelmenkleister">
@@ -7056,16 +7071,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Schelmenlaune_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schelmenlaune">
@@ -7085,16 +7100,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Schelmenmaske_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schelmenmaske">
@@ -7114,16 +7129,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Schelmenrausch_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schelmenrausch">
@@ -7143,16 +7158,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Schlangenruf_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Schlangenruf">
@@ -7172,16 +7187,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_schleier_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_schleier">
@@ -7201,16 +7216,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_schwarzundrot_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_schwarzundrot">
@@ -7230,16 +7245,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_schwarzerschrecken_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_schwarzerschrecken">
@@ -7259,16 +7274,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Seelenfeuer_Lichterloh_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Seelenfeuer_Lichterloh">
@@ -7288,16 +7303,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_seelentier_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_seelentier">
@@ -7317,16 +7332,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_seelenwanderung_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_seelenwanderung">
@@ -7346,16 +7361,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_seidenweich_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_seidenweich">
@@ -7375,16 +7390,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_seidenzunge_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_seidenzunge">
@@ -7404,16 +7419,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_sensattacco_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sensattacco">
@@ -7433,16 +7448,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_sensibar_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sensibar">
@@ -7462,16 +7477,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_serpentialis_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_serpentialis">
@@ -7491,16 +7506,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_silentium_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_silentium">
@@ -7520,16 +7535,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_sinesigil_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sinesigil">
@@ -7549,16 +7564,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_skelettarius_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_skelettarius">
@@ -7578,16 +7593,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_solidirid_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_solidirid">
@@ -7607,16 +7622,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_somnigravis_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_somnigravis">
@@ -7636,16 +7651,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Sphaerovisio_Schreckensbild_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Sphaerovisio_Schreckensbild">
@@ -7665,16 +7680,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_spinnenlauf_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_spinnenlauf">
@@ -7694,16 +7709,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Spinnennetz_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Spinnennetz">
@@ -7723,16 +7738,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Spinnenruf_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Spinnenruf">
@@ -7752,16 +7767,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_spurlos_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_spurlos">
@@ -7781,16 +7796,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_standfest_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_standfest">
@@ -7810,16 +7825,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_staub_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_staub">
@@ -7839,16 +7854,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Steinmauer_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Steinmauer">
@@ -7868,16 +7883,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_stein_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_stein">
@@ -7897,16 +7912,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_stillstand_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_stillstand">
@@ -7926,16 +7941,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Stimmen_des_Windes_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Stimmen_des_Windes">
@@ -7955,16 +7970,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Sumpfstrudel_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Sumpfstrudel">
@@ -7984,16 +7999,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_sumus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sumus">
@@ -8013,16 +8028,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Tanz_der_Erloesung_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Tanz_der_Erloesung">
@@ -8042,16 +8057,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_tauschrausch_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tauschrausch">
@@ -8071,16 +8086,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_tempus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tempus">
@@ -8100,16 +8115,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Thargunitothbann_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Thargunitothbann">
@@ -8129,16 +8144,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_tiere_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tiere">
@@ -8158,16 +8173,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_tiergedanken_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tiergedanken">
@@ -8187,16 +8202,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Tierruf_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Tierruf">
@@ -8216,16 +8231,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_tlalucs_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tlalucs">
@@ -8245,16 +8260,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_totes_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_totes">
@@ -8274,16 +8289,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_transformatio_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_transformatio">
@@ -8303,16 +8318,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_transmutare_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_transmutare">
@@ -8332,16 +8347,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_transversalis_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_transversalis">
@@ -8361,16 +8376,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Traumgestalt_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Traumgestalt">
@@ -8390,16 +8405,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Umbraporta_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Umbraporta">
@@ -8419,16 +8434,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_unberuhrt_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_unberuhrt">
@@ -8448,16 +8463,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_unitatio_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_unitatio">
@@ -8477,16 +8492,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Unsichtbare_Glut_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Unsichtbare_Glut">
@@ -8506,16 +8521,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_unsichtbarer_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_unsichtbarer">
@@ -8535,16 +8550,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Valetudo_Lebenskraft_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Valetudo_Lebenskraft">
@@ -8564,16 +8579,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_veranderung_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_veranderung">
@@ -8593,16 +8608,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_verschwindibus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_verschwindibus">
@@ -8622,16 +8637,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_verstandigung_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_verstandigung">
@@ -8651,16 +8666,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_verwandlung_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_verwandlung">
@@ -8680,16 +8695,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_vipernblick_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_vipernblick">
@@ -8709,16 +8724,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_visibili_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_visibili">
@@ -8738,16 +8753,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_vocolimbo_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_vocolimbo">
@@ -8767,16 +8782,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_vogelzwitschern_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_vogelzwitschern">
@@ -8796,16 +8811,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_wandausdornen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_wandausdornen">
@@ -8825,16 +8840,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Wand_aus_Flammen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Wand_aus_Flammen">
@@ -8854,16 +8869,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_warmes_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_warmes">
@@ -8883,16 +8898,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Warmes_gefriere_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Warmes_gefriere">
@@ -8912,16 +8927,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_wasseratem_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_wasseratem">
@@ -8941,16 +8956,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Wasserwall_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Wasserwall">
@@ -8970,16 +8985,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_weiches_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_weiches">
@@ -8999,16 +9014,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_weihrauchwolke_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_weihrauchwolke">
@@ -9028,16 +9043,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_weisheit_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_weisheit">
@@ -9057,16 +9072,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_dz_Weisheit_der_Steine_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Weisheit_der_Steine">
@@ -9086,16 +9101,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_weisse_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_weisse">
@@ -9115,16 +9130,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_wellenlauf_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_wellenlauf">
@@ -9144,16 +9159,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_wettermeisterschaft_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_wettermeisterschaft">
@@ -9173,16 +9188,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_widerwille_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_widerwille">
@@ -9202,16 +9217,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Windbarriere_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Windbarriere">
@@ -9231,16 +9246,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Windgefluester_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Windgefluester">
@@ -9260,16 +9275,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Windhose_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Windhose">
@@ -9289,16 +9304,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Windstille_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Windstille">
@@ -9318,16 +9333,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Wipfellauf_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Wipfellauf">
@@ -9347,16 +9362,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_xenographus_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_xenographus">
@@ -9376,16 +9391,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_zagibu_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zagibu">
@@ -9405,16 +9420,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Zappenduster_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Zappenduster">
@@ -9434,16 +9449,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_zauberklinge_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zauberklinge">
@@ -9463,16 +9478,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_zaubernahrung_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zaubernahrung">
@@ -9492,16 +9507,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_zauberwesen_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zauberwesen">
@@ -9521,16 +9536,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_zauberzwang_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zauberzwang">
@@ -9550,16 +9565,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_zorn_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zorn">
@@ -9579,16 +9594,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_zunge_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zunge">
@@ -9608,16 +9623,16 @@
 					<div class="talent-cell talent-rep">
 						<select type="text" name="attr_z_Zwingtanz_rep">
 							<option value="">---</option>
-							<option value="Mag">gildenmagisch</option>
-							<option value="Elf">elfisch</option>
-							<option value="Dru">druidisch</option>
-							<option value="Sat">satuarisch</option>
-							<option value="Geo">geodisch</option>
-							<option value="Sch">schelmisch</option>
-							<option value="Srl">scharlatanisch</option>
-							<option value="Bor">borbaradianisch</option>
-							<option value="Ach">kristallomantisch</option>
-							<option value="Kop">kophtanisch</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
 						</select>
 					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Zwingtanz">

--- a/Das_Schwarze_Auge_4-1/dev/js/magic.js
+++ b/Das_Schwarze_Auge_4-1/dev/js/magic.js
@@ -6,184 +6,184 @@ on(spells.map(spell => "clicked:" + spell + "-action").join(" "), async (info) =
 	var nameUI = spellsData[trigger]["ui"];
 	var stats = spellsData[trigger]["stats"];
 	debugLog(func, trigger, spellsData[trigger]);
-
-	// Build Roll Macro
-	var rollMacro = "";
-
-	rollMacro +=
-		"@{gm_roll_opt} " +
-		"&{template:zauber} " +
-		"{{name=" + nameUI + "}} " +
-		"{{wert=[[@{ZfW_" + nameInternal + "}d1cs0cf2]]}} " +
-		"{{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} " +
-		"{{stats=[[ " +
-			"[Eigenschaft 1:] [[@{" + stats[0] + "}]]d1cs0cf2 + " +
-			"[Eigenschaft 2:] [[@{" + stats[1] + "}]]d1cs0cf2 + " +
-			"[Eigenschaft 3:] [[@{" + stats[2] + "}]]d1cs0cf2" +
-			"]]}} " +
-		"{{roll=[[3d20cs<@{cs_zauber}cf>@{cf_zauber}]]}} " +
-		"{{result=[[0]]}} " +
-		"{{criticality=[[0]]}} " +
-		"{{critThresholds=[[[[@{cs_zauber}]]d1cs0cf2 + [[@{cf_zauber}]]d1cs0cf2]]}} ";
-	debugLog(func, rollMacro);
-
-	// Execute Roll
-	results = await startRoll(rollMacro);
-	console.log("test: info:", info, "results:", results);
-	var rollID = results.rollId;
-	results = results.results;
-	var TaW = results.wert.result;
-	var mod = results.mod.result;
-	var stats = [
-		results.stats.rolls[0].dice,
-		results.stats.rolls[1].dice,
-		results.stats.rolls[2].dice
-	];
-	var rolls = results.roll.rolls[0].results;
-	var success = results.critThresholds.rolls[0].dice;
-	var failure = results.critThresholds.rolls[1].dice;
-	/* Result
-	-1	Failure (due to Firm Matrix)
-	 0	Failure
-	 1	Success
-	 2	Success (due to Firm Matrix)
-	*/
-	var result = 0;
-	/* Criticality
-	-4	Two or more dice same result (not 1, not 20); via Spell Stalling (Spruchhemmung)
-	-3	Triple 20
-	-2	Double 20
-	 0	no double 1/20
-	+2	Double 1
-	+3	Triple 1
-	*/
-	var criticality = 0;
-
-	safeGetAttrs(["v_festematrix", "n_spruchhemmung"], function(v) {
-		/*
-			Doppel/Dreifach-1/20-Berechnung
-			Vor der TaP*-Berechnung, da diese damit gegebenenfalls hinfällig wird
+	safeGetAttrs(["KL", "IN", "z_repraesentation", "v_festematrix", "n_spruchhemmung"], async function (v) {
+		/* deal with elven representation:
+			if representation is elven and KL > IN, replace first KL with IN 
 		*/
-		/*
-		Variable, um festhalten zu können, dass ein
-			* normal misslungenes Ergebnis ohne Feste Matrix automatisch misslungen wäre und
-			* normal gelungenes Ergebnis ohne Feste Matrix automatisch misslungen wäre
-		*/
-		var festeMatrixSave = false;
-		{
-			let successes = 0;
-			let failures = 0;
-			let festeMatrix = v["v_festematrix"] === "0" ? false : true;
-			let spruchhemmung = v["n_spruchhemmung"] === "0" ? false : true;
-
-			for (roll of rolls)
-			{
-				if (roll <= success)
-				{
-					successes += 1;
-				} else if (roll >= failure) {
-					failures += 1;
-				}
-				if (successes >= 2)
-				{
-					criticality = successes;
-				} else if (failures >= 2) {
-					criticality = -failures;
-				}
+		if (v["subtag1"] === "Elf" && v["KL"] < v["IN"]) {
+			if (stats[0] === "KL" && (stats[1] !== "IN" || stats[2] !== "IN")) {
+				stats[0] = "IN";
+			} else if (stats[1] === "KL") {
+				stats[1] = "IN";
+			} else if (stats[2] === "KL") {
+				stats[2] = "IN";
 			}
-			// feste Matrix
-			if (festeMatrix && criticality === -2)
-			{
-				criticality = -1;
-				festeMatrixSave = true;
+		}
+		
+		// Build Roll Macro
+		var rollMacro = "";
 
-				for (roll of rolls)
-				{
-					if (
-						(roll > success) &&
-						(roll < failure) &&
-						(
-							roll === 18 || roll === 19
-						)
-					)
-					{
-						criticality -= 1;
-						festeMatrixSave = false;
+		rollMacro +=
+			"@{gm_roll_opt} " +
+			"&{template:zauber} " +
+			"{{name=" + nameUI + "}} " +
+			"{{wert=[[@{ZfW_" + nameInternal + "}d1cs0cf2]]}} " +
+			"{{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} " +
+			"{{stats=[[ " +
+				"[Eigenschaft 1:] [[@{" + stats[0] + "}]]d1cs0cf2 + " +
+				"[Eigenschaft 2:] [[@{" + stats[1] + "}]]d1cs0cf2 + " +
+				"[Eigenschaft 3:] [[@{" + stats[2] + "}]]d1cs0cf2" +
+				"]]}} " +
+			"{{roll=[[3d20cs<@{cs_zauber}cf>@{cf_zauber}]]}} " +
+			"{{result=[[0]]}} " +
+			"{{criticality=[[0]]}} " +
+			"{{critThresholds=[[[[@{cs_zauber}]]d1cs0cf2 + [[@{cf_zauber}]]d1cs0cf2]]}} ";
+		debugLog(func, rollMacro);
+
+		// Execute Roll
+		startRoll(rollMacro).then((results) => {
+			console.log("test: info:", info, "results:", results);
+			var rollID = results.rollId;
+			results = results.results;
+			var TaW = results.wert.result;
+			var mod = results.mod.result;
+			var stats = [
+				results.stats.rolls[0].dice,
+				results.stats.rolls[1].dice,
+				results.stats.rolls[2].dice
+			];
+			var rolls = results.roll.rolls[0].results;
+			var success = results.critThresholds.rolls[0].dice;
+			var failure = results.critThresholds.rolls[1].dice;
+			/* Result
+			-1	Failure (due to Firm Matrix)
+			0	Failure
+			1	Success
+			2	Success (due to Firm Matrix)
+			*/
+			var result = 0;
+			/* Criticality
+			-4	Two or more dice same result (not 1, not 20); via Spell Stalling (Spruchhemmung)
+			-3	Triple 20
+			-2	Double 20
+			0	no double 1/20
+			+2	Double 1
+			+3	Triple 1
+			*/
+			var criticality = 0;
+
+
+			/*
+				Doppel/Dreifach-1/20-Berechnung
+				Vor der TaP*-Berechnung, da diese damit gegebenenfalls hinfällig wird
+			*/
+			/*
+			Variable, um festhalten zu können, dass ein
+				* normal misslungenes Ergebnis ohne Feste Matrix automatisch misslungen wäre und
+				* normal gelungenes Ergebnis ohne Feste Matrix automatisch misslungen wäre
+			*/
+			var festeMatrixSave = false;
+			{
+				let successes = 0;
+				let failures = 0;
+				let festeMatrix = v["v_festematrix"] === "0" ? false : true;
+				let spruchhemmung = v["n_spruchhemmung"] === "0" ? false : true;
+
+				for (roll of rolls) {
+					if (roll <= success) {
+						successes += 1;
+					} else if (roll >= failure) {
+						failures += 1;
+					}
+					if (successes >= 2) {
+						criticality = successes;
+					} else if (failures >= 2) {
+						criticality = -failures;
 					}
 				}
-			}
-			// Spruchhemmung, soll nur auslösen, wenn eh nicht Doppel/Dreifach-1/20
-			if (
-				spruchhemmung &&
-				criticality > -2 &&
-				criticality < 2 &&
-				(
-					(rolls[0] === rolls[1]) ||
-					(rolls[1] === rolls[2]) ||
-					(rolls[2] === rolls[0])
-				)
-			)
-			{
-				criticality = -4;
-			}
-		}
+				// feste Matrix
+				if (festeMatrix && criticality === -2) {
+					criticality = -1;
+					festeMatrixSave = true;
 
-		/*
-			TaP*-Berechnung
-		*/
-		var effRolls = rolls;
-		var effTaW = TaW - mod;
-		var TaPstar = effTaW;
-
-		// Negativer TaW: |effTaW| zu Teilwürfen addieren
-		if (criticality >= 2)
-		{
-			TaPstar = TaW;
-			result = 1;
-		} else {
-			if (effTaW < 0)
-			{
-				for (roll in rolls)
-				{
-					effRolls[roll] = rolls[roll] + Math.abs(effTaW);
+					for (roll of rolls) {
+						if (
+							(roll > success) &&
+							(roll < failure) &&
+							(
+								roll === 18 || roll === 19
+							)
+						) {
+							criticality -= 1;
+							festeMatrixSave = false;
+						}
+					}
 				}
-				TaPstar = 0;
-			}
-
-			// TaP-Verbrauch für jeden Wurf
-			for (roll in effRolls)
-			{
-				TaPstar -= Math.max(0, effRolls[roll] - stats[roll]);
-			}
-
-			// Max. TaP* = TaW, mindestens aber 0
-			TaPstar = Math.min(Math.max(TaW, 0), TaPstar);
-
-			// Ergebnis an Doppel/Dreifach-20 anpassen
-			if (Math.abs(criticality) <= 1)
-			{
-				result = TaPstar < 0 ? 0 : 1;
-				if (festeMatrixSave && result === 0)
-				{
-					result = -1;
-				} else if (festeMatrixSave && result === 1)
-				{
-					result = 2;
+				// Spruchhemmung, soll nur auslösen, wenn eh nicht Doppel/Dreifach-1/20
+				if (
+					spruchhemmung &&
+					criticality > -2 &&
+					criticality < 2 &&
+					(
+						(rolls[0] === rolls[1]) ||
+						(rolls[1] === rolls[2]) ||
+						(rolls[2] === rolls[0])
+					)
+				) {
+					criticality = -4;
 				}
-			} else if (criticality <= -2) {
-				result = 0;
 			}
-		}
 
-		finishRoll(
-			rollID,
-			{
-				roll: TaPstar,
-				result: result,
-				criticality: criticality,
-				stats: stats.toString().replaceAll(",", "/")
+			/*
+				TaP*-Berechnung
+			*/
+			var effRolls = rolls;
+			var effTaW = TaW - mod;
+			var TaPstar = effTaW;
+
+			// Negativer TaW: |effTaW| zu Teilwürfen addieren
+			if (criticality >= 2) {
+				TaPstar = TaW;
+				result = 1;
+			} else {
+				if (effTaW < 0) {
+					for (roll in rolls) {
+						effRolls[roll] = rolls[roll] + Math.abs(effTaW);
+					}
+					TaPstar = 0;
+				}
+
+				// TaP-Verbrauch für jeden Wurf
+				for (roll in effRolls) {
+					TaPstar -= Math.max(0, effRolls[roll] - stats[roll]);
+				}
+
+				// Max. TaP* = TaW
+				TaPstar = Math.min(TaW, TaPstar);
+
+				// Ergebnis an Doppel/Dreifach-20 anpassen
+				if (Math.abs(criticality) <= 1) {
+					result = TaPstar < 0 ? 0 : 1;
+					if (festeMatrixSave && result === 0) {
+						result = -1;
+					} else if (festeMatrixSave && result === 1) {
+						result = 2;
+					}
+				} else if (criticality <= -2) {
+					result = 0;
+				}
 			}
-		);
+
+			finishRoll(
+				rollID,
+				{
+					roll: TaPstar,
+					result: result,
+					criticality: criticality,
+					stats: stats.toString().replaceAll(",", "/")
+				}
+			);
+		});
 	});
 });
 /* magic end */

--- a/Das_Schwarze_Auge_4-1/dev/js/migration.js
+++ b/Das_Schwarze_Auge_4-1/dev/js/migration.js
@@ -12,7 +12,7 @@ var versionsWithMigrations = [
 		20220604,
 		20220821,
 		20230618,
-		20240414
+		20240414,
 		20240421
 ];
 
@@ -906,7 +906,7 @@ function migrateTo20240414(migrationChain) {
 }
 
 /*
-	Migration steps: rename attribute subtag1 to z_repraesentation and map its value
+	Migration steps: rename attribute subtag1 to z_erstrepraesentation and map its value
 */
 function migrateTo20240421(migrationChain) {
 	var caller = "migrateTo20240421";
@@ -925,7 +925,7 @@ function migrateTo20240421(migrationChain) {
 	}
 	safeGetAttrs(["subtag1"], function (v) {
 		let attrsToChange = {
-			"z_erstrepraesentation": valueMap[v[subtag1]]
+			"z_erstrepraesentation": valueMap[v["subtag1"]]
 		}
 		safeSetAttrs(attrsToChange, {}, function () {
 			callNextMigration(migrationChain);

--- a/Das_Schwarze_Auge_4-1/dev/js/migration.js
+++ b/Das_Schwarze_Auge_4-1/dev/js/migration.js
@@ -829,35 +829,6 @@ function migrateTo20230618(migrationChain) {
 			});
 		});
 	});
-
-	/*
-	Migration steps: rename attribute subtag1 to z_repraesentation and map its value*/
-	function migrateTo20240421(migrationChain) {
-		var caller = "migrateTo20240314";
-		debugLog(caller, "Invoked.");
-		let valueMap = {
-			"---": "",
-			"gildenmagisch": "Mag",
-			"elfisch": "Elf",
-			"druidisch": "Dru",
-			"satuarisch": "Sat",
-			"geodisch": "Geo",
-			"schelmisch": "Sch",
-			"scharlatanisch": "Srl",
-			"borbaradianisch": "Bor",
-			"kristallomantisch": "Ach"
-		}
-		safeGetAttrs(["subtag1"], function (v) {
-			let attrsToChange = {
-				"z_repraesentation": valueMap[v[subtag1]]
-			}
-			safeSetAttrs(attrsToChange, {}, function () {
-				callNextMigration(migrationChain);
-			});
-		});
-		
-	}	
-
 }
 
 /*
@@ -932,4 +903,34 @@ function migrateTo20240414(migrationChain) {
 		});
 	});
 }
+}
+
+/*
+	Migration steps: rename attribute subtag1 to z_repraesentation and map its value
+*/
+function migrateTo20240421(migrationChain) {
+	var caller = "migrateTo20240421";
+	debugLog(caller, "Invoked.");
+	let valueMap = {
+		"---": "",
+		"gildenmagisch": "Mag",
+		"elfisch": "Elf",
+		"druidisch": "Dru",
+		"satuarisch": "Sat",
+		"geodisch": "Geo",
+		"schelmisch": "Sch",
+		"scharlatanisch": "Srl",
+		"borbaradianisch": "Bor",
+		"kristallomantisch": "Ach"
+	}
+	safeGetAttrs(["subtag1"], function (v) {
+		let attrsToChange = {
+			"z_erstrepraesentation": valueMap[v[subtag1]]
+		}
+		safeSetAttrs(attrsToChange, {}, function () {
+			callNextMigration(migrationChain);
+		});
+	});
+	
+}	
 /* migration end */

--- a/Das_Schwarze_Auge_4-1/dev/js/migration.js
+++ b/Das_Schwarze_Auge_4-1/dev/js/migration.js
@@ -13,6 +13,7 @@ var versionsWithMigrations = [
 		20220821,
 		20230618,
 		20240414
+		20240421
 ];
 
 /*
@@ -828,6 +829,35 @@ function migrateTo20230618(migrationChain) {
 			});
 		});
 	});
+
+	/*
+	Migration steps: rename attribute subtag1 to z_repraesentation and map its value*/
+	function migrateTo20240421(migrationChain) {
+		var caller = "migrateTo20240314";
+		debugLog(caller, "Invoked.");
+		let valueMap = {
+			"---": "",
+			"gildenmagisch": "Mag",
+			"elfisch": "Elf",
+			"druidisch": "Dru",
+			"satuarisch": "Sat",
+			"geodisch": "Geo",
+			"schelmisch": "Sch",
+			"scharlatanisch": "Srl",
+			"borbaradianisch": "Bor",
+			"kristallomantisch": "Ach"
+		}
+		safeGetAttrs(["subtag1"], function (v) {
+			let attrsToChange = {
+				"z_repraesentation": valueMap[v[subtag1]]
+			}
+			safeSetAttrs(attrsToChange, {}, function () {
+				callNextMigration(migrationChain);
+			});
+		});
+		
+	}	
+
 }
 
 /*

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -780,6 +780,14 @@ The solution: convert the <input>s to type="text" and make them look like normal
 	width: 13.25em !important;
 }
 
+.charsheet .talent-rep {
+	width: 4.5em !important;
+}
+
+.charsheet .talent-rep select {
+	width: 100%;
+}
+
 .charsheet .talent-eigenschaft {
 	width: 4.25em !important;
 }
@@ -819,6 +827,11 @@ The solution: convert the <input>s to type="text" and make them look like normal
 .charsheet button.abbr > span {
 	text-decoration-line: underline;
 	text-decoration-style: dotted;
+}
+
+/* spell spec & ZfW input */
+.charsheet .section-Zauberbogen .zauber input {
+	vertical-align: baseline;
 }
 
 /*---------------------------------------------Aktivierung---------------------------------------*/

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -7279,8 +7279,8 @@
 		</table>
 		<br>
 		<div class="section section-Zauberbogen" align="center">
-			<b>Repräsentation</b>
-			<select type="text" name="attr_z_repraesentation" style="width: 12em;">
+			<b>Erstrepräsentation</b>
+			<select type="text" name="attr_z_erstrepraesentation" style="width: 12em;">
 				<option value="">---</option>
 				<option value="Mag">gildenmagisch</option>
 				<option value="Elf">elfisch</option>
@@ -7291,6 +7291,7 @@
 				<option value="Srl">scharlatanisch</option>
 				<option value="Bor">borbaradianisch</option>
 				<option value="Ach">kristallomantisch</option>
+				<option value="Kop">kophtanisch</option>
 			</select>
 			<br>
 			<b>Merkmale</b>
@@ -7309,6 +7310,7 @@
 				<div style="display:inline-block">
 					<div class="talent-cell talent-name talent-head">Zauber</div>
 					<div class="talent-cell talent-eigenschaften talent-head">Eigenschaften</div>
+					<div class="talent-cell talent-rep talent-head" title="Repräsentation ('---' verwendet Erstrepräsentation)">Rep.</div>
 					<div class="talent-cell talent-spez talent-head">Spezialisierung</div>
 					<div class="talent-cell talent-taw talent-head">ZfW</div>
 					<div class="talent-cell talent-taw talent-head">Seite</div>
@@ -7322,6 +7324,21 @@
 						<button type="roll" name="roll_z_abvenenum" value="@{z_abvenenum_action}"> <span>Abvenenum Reine Speise</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF + <span class="abbr" title="Modifikator abhängig von Giftstufe, Krankheit und Genießbarkeit (frisch, verdorben)">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_abvenenum_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_abvenenum">
 					<input type="number" class="talent-taw" name="attr_ZfW_abvenenum" min="0" value="0">
 					<div class="talent-cell talent-taw">11</div>
@@ -7336,6 +7353,21 @@
 						<button type="roll" name="roll_z_accuratum" value="@{z_accuratum_action}"> <span>Accuratum Zaubernadel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Schwierigkeit der Schneiderarbeit">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_accuratum_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_accuratum">
 					<input type="number" class="talent-taw" name="attr_ZfW_accuratum" min="0" value="0">
 					<div class="talent-cell talent-taw">12</div>
@@ -7350,6 +7382,21 @@
 						<button type="roll" name="roll_z_adamantium" value="@{z_adamantium_action}"> <span>Adamantium Erzstruktur</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Adamantium_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Adamantium">
 					<input type="number" class="talent-taw" name="attr_ZfW_Adamantium" min="0" value="0">
 					<div class="talent-cell talent-taw">13</div>
@@ -7364,6 +7411,21 @@
 						<button type="roll" name="roll_z_adlerauge" value="@{z_adlerauge_action}"> <span>Adlerauge Luchsenohr</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Adlerauge_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Adlerauge">
 					<input type="number" class="talent-taw" name="attr_ZfW_Adlerauge" min="0" value="0">
 					<div class="talent-cell talent-taw">15</div>
@@ -7378,6 +7440,21 @@
 						<button type="roll" name="roll_z_adlerschwinge" value="@{z_adlerschwinge_action}"> <span>Adlerschwinge Wolfsgestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Adlerschwinge_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Adlerschwinge">
 					<input type="number" class="talent-taw" name="attr_ZfW_Adlerschwinge" min="0" value="0">
 					<div class="talent-cell talent-taw">16</div>
@@ -7392,6 +7469,21 @@
 						<button type="roll" name="roll_z_aeolitus" value="@{z_aeolitus_action}"> <span>Aeolitus Windgebraus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aeolitus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aeolitus">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aeolitus" min="0" value="0">
 					<div class="talent-cell talent-taw">18</div>
@@ -7406,6 +7498,21 @@
 						<button type="roll" name="roll_z_aerofugo" value="@{z_aerofugo_action}"> <span>Aerofugo Vakuum</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aerofugo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aerofugo">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aerofugo" min="0" value="0">
 					<div class="talent-cell talent-taw">19</div>
@@ -7420,6 +7527,21 @@
 						<button type="roll" name="roll_z_aerogelo" value="@{z_aerogelo_action}"> <span>Aerogelo Atemqual</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aerogelo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aerogelo">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aerogelo" min="0" value="0">
 					<div class="talent-cell talent-taw">20</div>
@@ -7434,6 +7556,21 @@
 						<button type="roll" name="roll_z_aeropulvis" value="@{z_aeropulvis_action}"> <span>Aeropulvis Sanfter Fall</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aeropulvis_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aeropulvis">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aeropulvis" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -7448,6 +7585,21 @@
 						<button type="roll" name="roll_z_dz_agrimothbann" value="@{z_dz_agrimothbann_action}"> <span>Agrimothbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Agrimothbann_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Agrimothbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_Agrimothbann" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -7462,6 +7614,21 @@
 						<button type="roll" name="roll_z_alpgestalt" value="@{z_alpgestalt_action}"> <span>Alpgestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/GE + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Alpgestalt_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Alpgestalt">
 					<input type="number" class="talent-taw" name="attr_ZfW_Alpgestalt" min="0" value="0">
 					<div class="talent-cell talent-taw">21</div>
@@ -7476,6 +7643,21 @@
 						<button type="roll" name="roll_z_analys" value="@{z_analys_action}"> <span>Analys Arcanstruktur</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN + <span class="abbr" title="Modifikator für die Analyseschwierigkeit">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Analys_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Analys">
 					<input type="number" class="talent-taw" name="attr_ZfW_Analys" min="0" value="0">
 					<div class="talent-cell talent-taw">22</div>
@@ -7490,6 +7672,21 @@
 						<button type="roll" name="roll_z_aengstelindern" value="@{z_aengstelindern_action}"> <span>Ängste lindern</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_angste_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_angste">
 					<input type="number" class="talent-taw" name="attr_ZfW_angste" min="0" value="0">
 					<div class="talent-cell talent-taw">23</div>
@@ -7504,6 +7701,21 @@
 						<button type="roll" name="roll_z_animatio" value="@{z_animatio_action}"> <span>Animatio Stummer Diener</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Animatio_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Animato">
 					<input type="number" class="talent-taw" name="attr_ZfW_Animato" min="0" value="0">
 					<div class="talent-cell talent-taw">24</div>
@@ -7518,6 +7730,21 @@
 						<button type="roll" name="roll_z_applicatus" value="@{z_applicatus_action}"> <span>Applicatus Zauberspeicher</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Applicatus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Applicatus">
 					<input type="number" class="talent-taw" name="attr_ZfW_Applicatus" min="0" value="0">
 					<div class="talent-cell talent-taw">25</div>
@@ -7532,6 +7759,21 @@
 						<button type="roll" name="roll_z_aquafaxius" value="@{z_aquafaxius_action}"> <span>Aquafaxius</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aquafaxius_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aquafaxius">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aquafaxius" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -7546,6 +7788,21 @@
 						<button type="roll" name="roll_z_aquaqueris" value="@{z_aquaqueris_action}"> <span>Aquaqueris Wasserfluch</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aquaqueris_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aquaqueris">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aquaqueris" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -7560,6 +7817,21 @@
 						<button type="roll" name="roll_z_aquasphaero" value="@{z_aquasphaero_action}"> <span>Aquasphaero</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aquasphaero_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aquasphaero">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aquasphaero" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -7574,6 +7846,21 @@
 						<button type="roll" name="roll_z_arachnea" value="@{z_arachnea_action}"> <span>Arachnea Krabbeltier</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Arachnea_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Arachnea">
 					<input type="number" class="talent-taw" name="attr_ZfW_Arachnea" min="0" value="0">
 					<div class="talent-cell talent-taw">26</div>
@@ -7588,6 +7875,21 @@
 						<button type="roll" name="roll_z_arcanovi" value="@{z_arcanovi_action}"> <span>Arcanovi Artefakt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Arcanovi_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Arcanovi">
 					<input type="number" class="talent-taw" name="attr_ZfW_Arcanovi" min="0" value="0">
 					<div class="talent-cell talent-taw">27</div>
@@ -7602,6 +7904,21 @@
 						<button type="roll" name="roll_z_archofaxius" value="@{z_archofaxius_action}"> <span>Archofaxius</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Archofaxius_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Archofaxius">
 					<input type="number" class="talent-taw" name="attr_ZfW_Archofaxius" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -7616,6 +7933,21 @@
 						<button type="roll" name="roll_z_archosphaero" value="@{z_archosphaero_action}"> <span>Archosphaero</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Archosphaero_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Archosphaero">
 					<input type="number" class="talent-taw" name="attr_ZfW_Archosphaero" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -7630,6 +7962,21 @@
 						<button type="roll" name="roll_z_armatrutz" value="@{z_armatrutz_action}"> <span>Armatrutz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Armatrutz_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Armatrutz">
 					<input type="number" class="talent-taw" name="attr_ZfW_Armatrutz" min="0" value="0">
 					<div class="talent-cell talent-taw">28</div>
@@ -7644,6 +7991,21 @@
 						<button type="roll" name="roll_z_atemnot" value="@{z_atemnot_action}"> <span>Atemnot</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Atemnot_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Atemnot">
 					<input type="number" class="talent-taw" name="attr_ZfW_Atemnot" min="0" value="0">
 					<div class="talent-cell talent-taw">29</div>
@@ -7669,6 +8031,21 @@
 							<option value="@{KK}">KK</option>
 						</select>
 					</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_attributo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Attributo">
 					<input type="number" class="talent-taw" name="attr_ZfW_Attributo" min="0" value="0">
 					<div class="talent-cell talent-taw">30</div>
@@ -7683,6 +8060,21 @@
 						<button type="roll" name="roll_z_aufgeblasen" value="@{z_aufgeblasen_action}"> <span>Aufgeblasen Abgehoben</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/KO/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aufgeblasen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aufgeblasen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aufgeblasen" min="0" value="0">
 					<div class="talent-cell talent-taw">31</div>
@@ -7697,6 +8089,21 @@
 						<button type="roll" name="roll_z_augedeslimbus" value="@{z_augedeslimbus_action}"> <span>Auge des Limbus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Auge_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Auge">
 					<input type="number" class="talent-taw" name="attr_ZfW_Auge" min="0" value="0">
 					<div class="talent-cell talent-taw">32</div>
@@ -7711,6 +8118,21 @@
 						<button type="roll" name="roll_z_aureolus" value="@{z_aureolus_action}"> <span>Aureolus Güldenglanz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Aureolus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Aureolus">
 					<input type="number" class="talent-taw" name="attr_ZfW_Aureolus" min="0" value="0">
 					<div class="talent-cell talent-taw">33</div>
@@ -7725,6 +8147,21 @@
 						<button type="roll" name="roll_z_aurisnasusoculus" value="@{z_aurisnasusoculus_action}"> <span>Auris Nasus Oculus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Auris_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Auris">
 					<input type="number" class="talent-taw" name="attr_ZfW_Auris" min="0" value="0">
 					<div class="talent-cell talent-taw">35</div>
@@ -7739,6 +8176,21 @@
 						<button type="roll" name="roll_z_axxeleratus" value="@{z_axxeleratus_action}"> <span>Axxeleratus Blitzgeschwind</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Axxeleratus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Axxeleratus">
 					<input type="number" class="talent-taw" name="attr_ZfW_Axxeleratus" min="0" value="0">
 					<div class="talent-cell talent-taw">36</div>
@@ -7753,6 +8205,21 @@
 						<button type="roll" name="roll_z_balsam" value="@{z_balsam_action}"> <span>Balsam Salabunde</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Heilung regeltechnischer Wunden">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Balsam_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Balsam">
 					<input type="number" class="talent-taw" name="attr_ZfW_Balsam" min="0" value="0">
 					<div class="talent-cell talent-taw">37</div>
@@ -7767,6 +8234,21 @@
 						<button type="roll" name="roll_z_bandundfessel" value="@{z_bandundfessel_action}"> <span>Band und Fessel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_band_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_band">
 					<input type="number" class="talent-taw" name="attr_ZfW_band" min="0" value="0">
 					<div class="talent-cell talent-taw">38</div>
@@ -7781,6 +8263,21 @@
 						<button type="roll" name="roll_z_bannbaladin" value="@{z_bannbaladin_action}"> <span>Bannbaladin</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Bannbaladin_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Bannbaladin">
 					<input type="number" class="talent-taw" name="attr_ZfW_Bannbaladin" min="0" value="0">
 					<div class="talent-cell talent-taw">39</div>
@@ -7795,6 +8292,21 @@
 						<button type="roll" name="roll_z_baerenruhe" value="@{z_baerenruhe_action}"> <span>Bärenruhe Winterschlaf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK + <span class="abbr" title="Modifikator für die Dauer des Schlafs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Barenruhe_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Barenruhe">
 					<input type="number" class="talent-taw" name="attr_ZfW_Barenruhe" min="0" value="0">
 					<div class="talent-cell talent-taw">40</div>
@@ -7809,6 +8321,21 @@
 						<button type="roll" name="roll_z_beherrschungbrechen" value="@{z_beherrschungbrechen_action}"> <span>Beherrschung brechen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Beherrschung_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Beherrschung">
 					<input type="number" class="talent-taw" name="attr_ZfW_Beherrschung" min="0" value="0">
 					<div class="talent-cell talent-taw">41</div>
@@ -7823,6 +8350,21 @@
 						<button type="roll" name="roll_z_dz_belzhorashbann" value="@{z_dz_belzhorashbann_action}"> <span>Belzhorashbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Belzhorashbann_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Belzhorashbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_Belzhorashbann" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -7837,6 +8379,21 @@
 						<button type="roll" name="roll_z_beschwoerungvereiteln" value="@{z_beschwoerungvereiteln_action}"> <span>Beschwörung vereiteln</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs und der beschworenen Wesenheit">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Beschworung_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Beschworung">
 					<input type="number" class="talent-taw" name="attr_ZfW_Beschworung" min="0" value="0">
 					<div class="talent-cell talent-taw">42</div>
@@ -7851,6 +8408,21 @@
 						<button type="roll" name="roll_z_bewegungstoeren" value="@{z_bewegungstoeren_action}"> <span>Bewegung stören</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Bewegung_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Bewegung">
 					<input type="number" class="talent-taw" name="attr_ZfW_Bewegung" min="0" value="0">
 					<div class="talent-cell talent-taw">43</div>
@@ -7865,6 +8437,21 @@
 						<button type="roll" name="roll_z_dz_bienenschwarm" value="@{z_dz_bienenschwarm_action}"> <span>Bienenschwarm</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Bienenschwarm_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Bienenschwarm">
 					<input type="number" class="talent-taw" name="attr_ZfW_Bienenschwarm" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -7879,6 +8466,21 @@
 						<button type="roll" name="roll_z_blendwerk" value="@{z_blendwerk_action}"> <span>Blendwerk</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Blendwerk_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Blendwerk">
 					<input type="number" class="talent-taw" name="attr_ZfW_Blendwerk" min="0" value="0">
 					<div class="talent-cell talent-taw">44</div>
@@ -7893,6 +8495,21 @@
 						<button type="roll" name="roll_z_blickaufswesen" value="@{z_blickaufswesen_action}"> <span>Blick aufs Wesen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_blickaufswesen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_blickaufswesen">
 					<input type="number" class="talent-taw" name="attr_ZfW_blickaufswesen" min="0" value="0">
 					<div class="talent-cell talent-taw">45</div>
@@ -7907,6 +8524,21 @@
 						<button type="roll" name="roll_z_blickdurchfremdeaugen" value="@{z_blickdurchfremdeaugen_action}"> <span>Blick durch fremde Augen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_blickdurchfremdeaugen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_blickdurchfremdeaugen">
 					<input type="number" class="talent-taw" name="attr_ZfW_blickdurchfremdeaugen" min="0" value="0">
 					<div class="talent-cell talent-taw">46</div>
@@ -7921,6 +8553,21 @@
 						<button type="roll" name="roll_z_blickindiegedanken" value="@{z_blickindiegedanken_action}"> <span>Blick in die Gedanken</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_blickindiegedanken_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_blickindiegedanken">
 					<input type="number" class="talent-taw" name="attr_ZfW_blickindiegedanken" min="0" value="0">
 					<div class="talent-cell talent-taw">47</div>
@@ -7935,6 +8582,21 @@
 						<button type="roll" name="roll_z_blickindievergangenheit" value="@{z_blickindievergangenheit_action}"> <span>Blick in die Vergangenheit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN + <span class="abbr" title="Modifikator für die Zeitspanne, die zurückgeblickt werden soll">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_blickindievergangenheit_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_blickindievergangenheit">
 					<input type="number" class="talent-taw" name="attr_ZfW_blickindievergangenheit" min="0" value="0">
 					<div class="talent-cell talent-taw">48</div>
@@ -7949,6 +8611,21 @@
 						<button type="roll" name="roll_z_blitz" value="@{z_blitz_action}"> <span>Blitz dich find</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/GE + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Blitz_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Blitz">
 					<input type="number" class="talent-taw" name="attr_ZfW_Blitz" min="0" value="0">
 					<div class="talent-cell talent-taw">49</div>
@@ -7963,6 +8640,21 @@
 						<button type="roll" name="roll_z_boeserblick" value="@{z_boeserblick_action}"> <span>Böser Blick</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_boser_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_boser">
 					<input type="number" class="talent-taw" name="attr_ZfW_boser" min="0" value="0">
 					<div class="talent-cell talent-taw">50</div>
@@ -7977,6 +8669,21 @@
 						<button type="roll" name="roll_z_brenne" value="@{z_brenne_action}"> <span>Brenne, toter Stoff!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_brenne_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_brenne">
 					<input type="number" class="talent-taw" name="attr_ZfW_brenne" min="0" value="0">
 					<div class="talent-cell talent-taw">51</div>
@@ -7991,6 +8698,21 @@
 						<button type="roll" name="roll_z_caldofrigo" value="@{z_caldofrigo_action}"> <span>Caldofrigo Heiß und Kalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_caldofrigo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_caldofrigo">
 					<input type="number" class="talent-taw" name="attr_ZfW_caldofrigo" min="0" value="0">
 					<div class="talent-cell talent-taw">52</div>
@@ -8005,6 +8727,21 @@
 						<button type="roll" name="roll_z_chamaelioni" value="@{z_chamaelioni_action}"> <span>Chamaelioni Mimikry</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_chamaelioni_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_chamaelioni">
 					<input type="number" class="talent-taw" name="attr_ZfW_chamaelioni" min="0" value="0">
 					<div class="talent-cell talent-taw">54</div>
@@ -8019,6 +8756,21 @@
 						<button type="roll" name="roll_z_chimaeroform" value="@{z_chimaeroform_action}"> <span>Chimaeroform Hybridgestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für den Verwandtschaftsgrad der Wesen, den Größenunterschied zwischen den Wesen, weiteren speziellen Fähigkeiten und den Umständen">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_chimaeroform_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_chimaeroform">
 					<input type="number" class="talent-taw" name="attr_ZfW_chimaeroform" min="0" value="0">
 					<div class="talent-cell talent-taw">55</div>
@@ -8033,6 +8785,21 @@
 						<button type="roll" name="roll_z_chronoklassis" value="@{z_chronoklassis_action}"> <span>Chronoklassis Urfossil</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für den Zeitabstand, die Genauigkeit des Wissens über die Zeit, des Ortes und der Entfernung zum Ort">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_chronoklassis_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_chronoklassis">
 					<input type="number" class="talent-taw" name="attr_ZfW_chronoklassis" min="0" value="0">
 					<div class="talent-cell talent-taw">56</div>
@@ -8047,6 +8814,21 @@
 						<button type="roll" name="roll_z_chrononautos" value="@{z_chrononautos_action}"> <span>Chrononautos Zeitenfahrt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für den Zeitabstand, den Transport von Ausrüstung und den Geburtszeitpunkten der Reisenden">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_chrononautos_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_chrononautos">
 					<input type="number" class="talent-taw" name="attr_ZfW_chrononautos" min="0" value="0">
 					<div class="talent-cell talent-taw">57</div>
@@ -8061,6 +8843,21 @@
 						<button type="roll" name="roll_z_claudibus" value="@{z_claudibus_action}"> <span>Claudibus Clavistibor</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_claudibus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_claudibus">
 					<input type="number" class="talent-taw" name="attr_ZfW_claudibus" min="0" value="0">
 					<div class="talent-cell talent-taw">58</div>
@@ -8075,6 +8872,21 @@
 						<button type="roll" name="roll_z_corpofesso" value="@{z_corpofesso_action}"> <span>Corpofesso Gliederschmerz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KO/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_corpofesso_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_corpofesso">
 					<input type="number" class="talent-taw" name="attr_ZfW_corpofesso" min="0" value="0">
 					<div class="talent-cell talent-taw">59</div>
@@ -8089,6 +8901,21 @@
 						<button type="roll" name="roll_z_corpofrigo" value="@{z_corpofrigo_action}"> <span>Corpofrigo Kälteschock</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/GE/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_corpofrigo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_corpofrigo">
 					<input type="number" class="talent-taw" name="attr_ZfW_corpofrigo" min="0" value="0">
 					<div class="talent-cell talent-taw">60</div>
@@ -8103,6 +8930,21 @@
 						<button type="roll" name="roll_z_cryptographo" value="@{z_cryptographo_action}"> <span>Cryptographo Zauberschrift</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_cryptographo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_cryptographo">
 					<input type="number" class="talent-taw" name="attr_ZfW_cryptographo" min="0" value="0">
 					<div class="talent-cell talent-taw">61</div>
@@ -8117,6 +8959,21 @@
 						<button type="roll" name="roll_z_custodosigil" value="@{z_custodosigil_action}"> <span>Custodosigil Diebesbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_custodosigil_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_custodosigil">
 					<input type="number" class="talent-taw" name="attr_ZfW_custodosigil" min="0" value="0">
 					<div class="talent-cell talent-taw">62</div>
@@ -8131,6 +8988,21 @@
 						<button type="roll" name="roll_z_daemonenbann" value="@{z_daemonenbann_action}"> <span>Dämonenbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_damonenbann_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_damonenbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_damonenbann" min="0" value="0">
 					<div class="talent-cell talent-taw">63</div>
@@ -8145,6 +9017,21 @@
 						<button type="roll" name="roll_z_delicioso" value="@{z_delicioso_action}"> <span>Delicioso Gaumenschmaus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_delicioso_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_delicioso">
 					<input type="number" class="talent-taw" name="attr_ZfW_delicioso" min="0" value="0">
 					<div class="talent-cell talent-taw">64</div>
@@ -8159,6 +9046,21 @@
 						<button type="roll" name="roll_z_desintegratus" value="@{z_desintegratus_action}"> <span>Desintegratus Pulverstaub</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_desintegratus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_desintegratus">
 					<input type="number" class="talent-taw" name="attr_ZfW_desintegratus" min="0" value="0">
 					<div class="talent-cell talent-taw">65</div>
@@ -8173,6 +9075,21 @@
 						<button type="roll" name="roll_z_destructibo" value="@{z_destructibo_action}"> <span>Destructibo Arcanitas</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF + <span class="abbr" title="Modifikator für die Einstimmungszeit und Beschaffenheit des Objekts">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_destructibo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_destructibo">
 					<input type="number" class="talent-taw" name="attr_ZfW_destructibo" min="0" value="0">
 					<div class="talent-cell talent-taw">66</div>
@@ -8187,6 +9104,21 @@
 						<button type="roll" name="roll_z_dichterunddenker" value="@{z_dichterunddenker_action}"> <span>Dichter und Denker</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dichter_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dichter">
 					<input type="number" class="talent-taw" name="attr_ZfW_dichter" min="0" value="0">
 					<div class="talent-cell talent-taw">67</div>
@@ -8201,6 +9133,21 @@
 						<button type="roll" name="roll_z_dschinnenruf" value="@{z_dschinnenruf_action}"> <span>Dschinnenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Dschinnenruf_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Dschinnenruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Dschinnenruf" min="0" value="0">
 					<div class="talent-cell talent-taw">68</div>
@@ -8215,6 +9162,21 @@
 						<button type="roll" name="roll_z_dunkelheit" value="@{z_dunkelheit_action}"> <span>Dunkelheit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Dunkelheit_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Dunkelheit">
 					<input type="number" class="talent-taw" name="attr_ZfW_Dunkelheit" min="0" value="0">
 					<div class="talent-cell talent-taw">69</div>
@@ -8229,6 +9191,21 @@
 						<button type="roll" name="roll_z_duplicatus" value="@{z_duplicatus_action}"> <span>Duplicatus Doppelbild</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/GE + <span class="abbr" title="2 pro zusätzlichem Doppelgänger">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_duplicatus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_duplicatus">
 					<input type="number" class="talent-taw" name="attr_ZfW_duplicatus" min="0" value="0">
 					<div class="talent-cell talent-taw">70</div>
@@ -8243,6 +9220,21 @@
 						<button type="roll" name="roll_z_ecliptifactus" value="@{z_ecliptifactus_action}"> <span>Ecliptifactus Schattenkraft</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_ecliptifactus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ecliptifactus">
 					<input type="number" class="talent-taw" name="attr_ZfW_ecliptifactus" min="0" value="0">
 					<div class="talent-cell talent-taw">71</div>
@@ -8257,6 +9249,21 @@
 						<button type="roll" name="roll_z_eigenschaftwiederherstellen" value="@{z_eigenschaftwiederherstellen_action}"> <span>Eigenschaft wiederherstellen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_eigenschaft_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eigenschaft">
 					<input type="number" class="talent-taw" name="attr_ZfW_eigenschaft" min="0" value="0">
 					<div class="talent-cell talent-taw">73</div>
@@ -8271,6 +9278,21 @@
 						<button type="roll" name="roll_z_eigneaengste" value="@{z_eigneaengste_action}"> <span>Eigne Ängste quälen dich!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_eigne_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eigne">
 					<input type="number" class="talent-taw" name="attr_ZfW_eigne" min="0" value="0">
 					<div class="talent-cell talent-taw">74</div>
@@ -8285,6 +9307,21 @@
 						<button type="roll" name="roll_z_einflussbannen" value="@{z_einflussbannen_action}"> <span>Einfluss bannen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_einfluss_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_einfluss">
 					<input type="number" class="talent-taw" name="attr_ZfW_einfluss" min="0" value="0">
 					<div class="talent-cell talent-taw">75</div>
@@ -8299,6 +9336,21 @@
 						<button type="roll" name="roll_z_einsmitdernatur" value="@{z_einsmitdernatur_action}"> <span>Eins mit der Natur</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_eins_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eins">
 					<input type="number" class="talent-taw" name="attr_ZfW_eins" min="0" value="0">
 					<div class="talent-cell talent-taw">76</div>
@@ -8313,6 +9365,21 @@
 						<button type="roll" name="roll_z_eisenrost" value="@{z_eisenrost_action}"> <span>Eisenrost und Patina</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_eisenrost_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eisenrost">
 					<input type="number" class="talent-taw" name="attr_ZfW_eisenrost" min="0" value="0">
 					<div class="talent-cell talent-taw">77</div>
@@ -8327,6 +9394,21 @@
 						<button type="roll" name="roll_z_eiseskaelte" value="@{z_eiseskaelte_action}"> <span>Eiseskälte Kämpferherz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_eiseskalte_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_eiseskalte">
 					<input type="number" class="talent-taw" name="attr_ZfW_eiseskalte" min="0" value="0">
 					<div class="talent-cell talent-taw">78</div>
@@ -8341,6 +9423,21 @@
 						<button type="roll" name="roll_z_eiswirbel" value="@{z_eiswirbel_action}"> <span>Eiswirbel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Eiswirbel_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Eiswirbel">
 					<input type="number" class="talent-taw" name="attr_ZfW_Eiswirbel" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -8355,6 +9452,21 @@
 						<button type="roll" name="roll_z_elementarbann" value="@{z_elementarbann_action}"> <span>Elementarbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Elementarbann_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Elementarbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_Elementarbann" min="0" value="0">
 					<div class="talent-cell talent-taw">79</div>
@@ -8369,6 +9481,21 @@
 						<button type="roll" name="roll_z_elementarerdiener" value="@{z_elementarerdiener_action}"> <span>Elementarer Diener</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_elementarer_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_elementarer">
 					<input type="number" class="talent-taw" name="attr_ZfW_elementarer" min="0" value="0">
 					<div class="talent-cell talent-taw">80</div>
@@ -8383,6 +9510,21 @@
 						<button type="roll" name="roll_z_elfenstimme" value="@{z_elfenstimme_action}"> <span>Elfenstimme Flötenton</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_elfenstimme_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_elfenstimme">
 					<input type="number" class="talent-taw" name="attr_ZfW_elfenstimme" min="0" value="0">
 					<div class="talent-cell talent-taw">81</div>
@@ -8397,6 +9539,21 @@
 						<button type="roll" name="roll_z_dz_entfesselungdesgetiers" value="@{z_dz_entfesselungdesgetiers_action}"> <span>Entfesselung des Getiers</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Entfesselung_des_Getiers_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Entfesselung_des_Getiers">
 					<input type="number" class="talent-taw" name="attr_ZfW_Entfesselung_des_Getiers" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -8411,6 +9568,21 @@
 						<button type="roll" name="roll_z_erinnerungverlassedich" value="@{z_erinnerungverlassedich_action}"> <span>Erinnerung verlasse dich!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_erinnerung_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_erinnerung">
 					<input type="number" class="talent-taw" name="attr_ZfW_erinnerung" min="0" value="0">
 					<div class="talent-cell talent-taw">82</div>
@@ -8425,6 +9597,21 @@
 						<button type="roll" name="roll_z_exposami" value="@{z_exposami_action}"> <span>Exposami Lebenskraft</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_exposami_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_exposami">
 					<input type="number" class="talent-taw" name="attr_ZfW_exposami" min="0" value="0">
 					<div class="talent-cell talent-taw">83</div>
@@ -8439,6 +9626,21 @@
 						<button type="roll" name="roll_z_falkenauge" value="@{z_falkenauge_action}"> <span>Falkenauge Meisterschuss</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_falkenauge_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_falkenauge">
 					<input type="number" class="talent-taw" name="attr_ZfW_falkenauge" min="0" value="0">
 					<div class="talent-cell talent-taw">84</div>
@@ -8453,6 +9655,21 @@
 						<button type="roll" name="roll_z_favilludo" value="@{z_favilludo_action}"> <span>Favilludo Funkentanz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_favilludo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_favilludo">
 					<input type="number" class="talent-taw" name="attr_ZfW_favilludo" min="0" value="0">
 					<div class="talent-cell talent-taw">85</div>
@@ -8467,6 +9684,21 @@
 						<button type="roll" name="roll_z_fesselranken" value="@{z_fesselranken_action}"> <span>Fesselranken</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Fesselranken_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Fesselranken">
 					<input type="number" class="talent-taw" name="attr_ZfW_Fesselranken" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -8481,6 +9713,21 @@
 						<button type="roll" name="roll_z_feuermaehne" value="@{z_feuermaehne_action}"> <span>Feuermähne Flammenhuf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Feuermaehne_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Feuermaehne">
 					<input type="number" class="talent-taw" name="attr_ZfW_Feuermaehne" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -8495,6 +9742,21 @@
 						<button type="roll" name="roll_z_feuersturm" value="@{z_feuersturm_action}"> <span>Feuersturm</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Feuersturm_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Feuersturm">
 					<input type="number" class="talent-taw" name="attr_ZfW_Feuersturm" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -8509,6 +9771,21 @@
 						<button type="roll" name="roll_z_firnlauf" value="@{z_firnlauf_action}"> <span>Firnlauf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Firnlauf_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Firnlauf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Firnlauf" min="0" value="0">
 					<div class="talent-cell talent-taw">86</div>
@@ -8523,6 +9800,21 @@
 						<button type="roll" name="roll_z_flimflam" value="@{z_flimflam_action}"> <span>Flim Flam Funkel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_flim_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_flim">
 					<input type="number" class="talent-taw" name="attr_ZfW_flim" min="0" value="0">
 					<div class="talent-cell talent-taw">87</div>
@@ -8537,6 +9829,21 @@
 						<button type="roll" name="roll_z_fluchderpestilenz" value="@{z_fluchderpestilenz_action}"> <span>Fluch der Pestilenz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_fluch_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_fluch">
 					<input type="number" class="talent-taw" name="attr_ZfW_fluch" min="0" value="0">
 					<div class="talent-cell talent-taw">88</div>
@@ -8551,6 +9858,21 @@
 						<button type="roll" name="roll_z_foramen" value="@{z_foramen_action}"> <span>Foramen Foraminor</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF + <span class="abbr" title="Modifikator für die Komplexität des Schlosses">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_foramen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_foramen">
 					<input type="number" class="talent-taw" name="attr_ZfW_foramen" min="0" value="0">
 					<div class="talent-cell talent-taw">89</div>
@@ -8565,6 +9887,21 @@
 						<button type="roll" name="roll_z_fortifex" value="@{z_fortifex_action}"> <span>Fortifex Arkane Wand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_fortifex_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_fortifex">
 					<input type="number" class="talent-taw" name="attr_ZfW_fortifex" min="0" value="0">
 					<div class="talent-cell talent-taw">90</div>
@@ -8579,6 +9916,21 @@
 						<button type="roll" name="roll_z_frigifaxius" value="@{z_frigifaxius_action}"> <span>Frigifaxius</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Frigifaxius_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Frigifaxius">
 					<input type="number" class="talent-taw" name="attr_ZfW_Frigifaxius" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -8593,6 +9945,21 @@
 						<button type="roll" name="roll_z_frigisphaero" value="@{z_frigisphaero_action}"> <span>Frigisphaero</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Frigisphaero_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Frigisphaero">
 					<input type="number" class="talent-taw" name="attr_ZfW_Frigisphaero" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -8607,6 +9974,21 @@
 						<button type="roll" name="roll_z_fulminictus" value="@{z_fulminictus_action}"> <span>Fulminictus Donnerkeil</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_fulminictus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_fulminictus">
 					<input type="number" class="talent-taw" name="attr_ZfW_fulminictus" min="0" value="0">
 					<div class="talent-cell talent-taw">91</div>
@@ -8621,6 +10003,21 @@
 						<button type="roll" name="roll_z_gardianum" value="@{z_gardianum_action}"> <span>Gardianum Zauberschild</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_gardianum_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_gardianum">
 					<input type="number" class="talent-taw" name="attr_ZfW_gardianum" min="0" value="0">
 					<div class="talent-cell talent-taw">92</div>
@@ -8635,6 +10032,21 @@
 						<button type="roll" name="roll_z_dz_gebieterdertiefe" value="@{z_dz_gebieterdertiefe_action}"> <span>Gebieter der Tiefe</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Gebieter_der_Tiefe_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Gebieter_der_Tiefe">
 					<input type="number" class="talent-taw" name="attr_ZfW_Gebieter_der_Tiefe" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -8649,6 +10061,21 @@
 						<button type="roll" name="roll_z_gedankenbilder" value="@{z_gedankenbilder_action}"> <span>Gedankenbilder Elfenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_gedankenbilder_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_gedankenbilder">
 					<input type="number" class="talent-taw" name="attr_ZfW_gedankenbilder" min="0" value="0">
 					<div class="talent-cell talent-taw">94</div>
@@ -8663,6 +10090,21 @@
 						<button type="roll" name="roll_z_gefaessderjahre" value="@{z_gefaessderjahre_action}"> <span>Gefäß der Jahre</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_gefass_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_gefass">
 					<input type="number" class="talent-taw" name="attr_ZfW_gefass" min="0" value="0">
 					<div class="talent-cell talent-taw">95</div>
@@ -8677,6 +10119,21 @@
 						<button type="roll" name="roll_z_gefunden" value="@{z_gefunden_action}"> <span>Gefunden!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/GE + <span class="abbr" title="Modifikator für den Abstand, die Größe, der Vertrautheit und weiteren Besonderheiten">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_gefunden_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_gefunden">
 					<input type="number" class="talent-taw" name="attr_ZfW_gefunden" min="0" value="0">
 					<div class="talent-cell talent-taw">96</div>
@@ -8691,6 +10148,21 @@
 						<button type="roll" name="roll_z_geisterbann" value="@{z_geisterbann_action}"> <span>Geisterbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Austreibungsschwierigkeit des Geistes">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Geisterbann_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Geisterbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_Geisterbann" min="0" value="0">
 					<div class="talent-cell talent-taw">97</div>
@@ -8705,6 +10177,21 @@
 						<button type="roll" name="roll_z_geisterruf" value="@{z_geisterruf_action}"> <span>Geisterruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Geistes">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Geisterruf_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Geisterruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Geisterruf" min="0" value="0">
 					<div class="talent-cell talent-taw">98</div>
@@ -8719,6 +10206,21 @@
 						<button type="roll" name="roll_z_dz_geschossderniederhoellen" value="@{z_dz_geschossderniederhoellen_action}"> <span>Geschoss der Niederhöllen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Geschoss_der_Niederhoellen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Geschoss_der_Niederhoellen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Geschoss_der_Niederhoellen" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -8733,6 +10235,21 @@
 						<button type="roll" name="roll_z_glacoflumen" value="@{z_glacoflumen_action}"> <span>Glacoflumen Fluss aus Eis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Glacoflumen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Glacoflumen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Glacoflumen" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -8747,6 +10264,21 @@
 						<button type="roll" name="roll_z_gletscherwand" value="@{z_gletscherwand_action}"> <span>Gletscherwand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Gletscherwand_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Gletscherwand">
 					<input type="number" class="talent-taw" name="attr_ZfW_Gletscherwand" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -8761,6 +10293,21 @@
 						<button type="roll" name="roll_z_granitundmarmor" value="@{z_granitundmarmor_action}"> <span>Granit und Marmor</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_granit_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_granit">
 					<input type="number" class="talent-taw" name="attr_ZfW_granit" min="0" value="0">
 					<div class="talent-cell talent-taw">99</div>
@@ -8775,6 +10322,21 @@
 						<button type="roll" name="roll_z_dz_grolmenseele" value="@{z_dz_grolmenseele_action}"> <span>Grolmenseele</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Grolmenseele_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Grolmenseele">
 					<input type="number" class="talent-taw" name="attr_ZfW_Grolmenseele" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -8789,6 +10351,21 @@
 						<button type="roll" name="roll_z_grossegier" value="@{z_grossegier_action}"> <span>Große Gier</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_grossegier_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_grossegier">
 					<input type="number" class="talent-taw" name="attr_ZfW_grossegier" min="0" value="0">
 					<div class="talent-cell talent-taw">100</div>
@@ -8803,6 +10380,21 @@
 						<button type="roll" name="roll_z_grosseverwirrung" value="@{z_grosseverwirrung_action}"> <span>Große Verwirrung</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_grosseverwirrung_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_grosseverwirrung">
 					<input type="number" class="talent-taw" name="attr_ZfW_grosseverwirrung" min="0" value="0">
 					<div class="talent-cell talent-taw">101</div>
@@ -8817,6 +10409,21 @@
 						<button type="roll" name="roll_z_halluzination" value="@{z_halluzination_action}"> <span>Halluzination</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Halluzination_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Halluzination">
 					<input type="number" class="talent-taw" name="attr_ZfW_Halluzination" min="0" value="0">
 					<div class="talent-cell talent-taw">102</div>
@@ -8831,6 +10438,21 @@
 						<button type="roll" name="roll_z_harmlosegestalt" value="@{z_harmlosegestalt_action}"> <span>Harmlose Gestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Harmlose_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Harmlose">
 					<input type="number" class="talent-taw" name="attr_ZfW_Harmlose" min="0" value="0">
 					<div class="talent-cell talent-taw">103</div>
@@ -8845,6 +10467,21 @@
 						<button type="roll" name="roll_z_hartesschmelze" value="@{z_hartesschmelze_action}"> <span>Hartes schmelze!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_hartes_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_hartes">
 					<input type="number" class="talent-taw" name="attr_ZfW_hartes" min="0" value="0">
 					<div class="talent-cell talent-taw">104</div>
@@ -8859,6 +10496,21 @@
 						<button type="roll" name="roll_z_haselbusch" value="@{z_haselbusch_action}"> <span>Haselbusch und Ginsterkraut</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_haselbusch_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_haselbusch">
 					<input type="number" class="talent-taw" name="attr_ZfW_haselbusch" min="0" value="0">
 					<div class="talent-cell talent-taw">105</div>
@@ -8873,6 +10525,21 @@
 						<button type="roll" name="roll_z_dz_hauchdertiefentochter" value="@{z_dz_hauchdertiefentochter_action}"> <span>Hauch der Tiefen Tochter</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Hauch_der_Tiefen_Tochter_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Hauch_der_Tiefen_Tochter">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hauch_der_Tiefen_Tochter" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -8887,6 +10554,21 @@
 						<button type="roll" name="roll_z_heilkraftbannen" value="@{z_heilkraftbannen_action}"> <span>Heilkraft bannen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_heilkraft_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_heilkraft">
 					<input type="number" class="talent-taw" name="attr_ZfW_heilkraft" min="0" value="0">
 					<div class="talent-cell talent-taw">107</div>
@@ -8901,6 +10583,21 @@
 						<button type="roll" name="roll_z_hellsichttrueben" value="@{z_hellsichttrueben_action}"> <span>Hellsicht trüben</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_hellsicht_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_hellsicht">
 					<input type="number" class="talent-taw" name="attr_ZfW_hellsicht" min="0" value="0">
 					<div class="talent-cell talent-taw">108</div>
@@ -8915,6 +10612,21 @@
 						<button type="roll" name="roll_z_herbeirufungvereiteln" value="@{z_herbeirufungvereiteln_action}"> <span>Herbeirufung vereiteln</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_herbeirufung_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_herbeirufung">
 					<input type="number" class="talent-taw" name="attr_ZfW_herbeirufung" min="0" value="0">
 					<div class="talent-cell talent-taw">109</div>
@@ -8929,6 +10641,21 @@
 						<button type="roll" name="roll_z_herrueberdastierreich" value="@{z_herrueberdastierreich_action}"> <span>Herr über das Tierreich</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_herr_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_herr">
 					<input type="number" class="talent-taw" name="attr_ZfW_herr" min="0" value="0">
 					<div class="talent-cell talent-taw">110</div>
@@ -8943,6 +10670,21 @@
 						<button type="roll" name="roll_z_herzschlagruhe" value="@{z_herzschlagruhe_action}"> <span>Herzschlag ruhe!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_herzschlag_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_herzschlag">
 					<input type="number" class="talent-taw" name="attr_ZfW_herzschlag" min="0" value="0">
 					<div class="talent-cell talent-taw">111</div>
@@ -8957,6 +10699,21 @@
 						<button type="roll" name="roll_z_dz_hexagrammadschinnenbann" value="@{z_dz_hexagrammadschinnenbann_action}"> <span>Hexagramma Dschinnenbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/IN + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit und Modifikationen nach WdZ 187">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Hexagramma_Dschinnenbann_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Hexagramma_Dschinnenbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexagramma_Dschinnenbann" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -8971,6 +10728,21 @@
 						<button type="roll" name="roll_z_hexenblick" value="@{z_hexenblick_action}"> <span>Hexenblick</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Hexenblick_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenblick">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexenblick" min="0" value="0">
 					<div class="talent-cell talent-taw">112</div>
@@ -8985,6 +10757,21 @@
 						<button type="roll" name="roll_z_hexengalle" value="@{z_hexengalle_action}"> <span>Hexengalle</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Hexengalle_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexengalle">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexengalle" min="0" value="0">
 					<div class="talent-cell talent-taw">113</div>
@@ -8999,6 +10786,21 @@
 						<button type="roll" name="roll_z_hexenholz" value="@{z_hexenholz_action}"> <span>Hexenholz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Hexenholz_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenholz">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexenholz" min="0" value="0">
 					<div class="talent-cell talent-taw">114</div>
@@ -9013,6 +10815,21 @@
 						<button type="roll" name="roll_z_hexenknoten" value="@{z_hexenknoten_action}"> <span>Hexenknoten</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Hexenknoten_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenknoten">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexenknoten" min="0" value="0">
 					<div class="talent-cell talent-taw">115</div>
@@ -9027,6 +10844,21 @@
 						<button type="roll" name="roll_z_hexenkrallen" value="@{z_hexenkrallen_action}"> <span>Hexenkrallen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Hexenkrallen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenkrallen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexenkrallen" min="0" value="0">
 					<div class="talent-cell talent-taw">116</div>
@@ -9041,6 +10873,21 @@
 						<button type="roll" name="roll_z_hexenspeichel" value="@{z_hexenspeichel_action}"> <span>Hexenspeichel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Hexenspeichel_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Hexenspeichel">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hexenspeichel" min="0" value="0">
 					<div class="talent-cell talent-taw">117</div>
@@ -9055,6 +10902,21 @@
 						<button type="roll" name="roll_z_hilfreichetatze" value="@{z_hilfreichetatze_action}"> <span>Hilfreiche Tatze</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="geistige Magieresistenz des Tieres">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_hilfreiche_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_hilfreiche">
 					<input type="number" class="talent-taw" name="attr_ZfW_hilfreiche" min="0" value="0">
 					<div class="talent-cell talent-taw">118</div>
@@ -9069,6 +10931,21 @@
 						<button type="roll" name="roll_z_hoellenpein" value="@{z_hoellenpein_action}"> <span>Höllenpein zerreiße dich!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_hollenpein_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_hollenpein">
 					<input type="number" class="talent-taw" name="attr_ZfW_hollenpein" min="0" value="0">
 					<div class="talent-cell talent-taw">119</div>
@@ -9083,6 +10960,21 @@
 						<button type="roll" name="roll_z_holterdipolter" value="@{z_holterdipolter_action}"> <span>Holterdipolter</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Holterdipolter_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Holterdipolter">
 					<input type="number" class="talent-taw" name="attr_ZfW_Holterdipolter" min="0" value="0">
 					<div class="talent-cell talent-taw">120</div>
@@ -9097,6 +10989,21 @@
 						<button type="roll" name="roll_z_dz_hornissenruf" value="@{z_dz_hornissenruf_action}"> <span>Hornissenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Hornissenruf_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Hornissenruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Hornissenruf" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -9111,6 +11018,21 @@
 						<button type="roll" name="roll_z_horriphobus" value="@{z_horriphobus_action}"> <span>Horriphobus Schreckgestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz vermindert um Aberglauben und Ängste">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_horriphobus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_horriphobus">
 					<input type="number" class="talent-taw" name="attr_ZfW_horriphobus" min="0" value="0">
 					<div class="talent-cell talent-taw">121</div>
@@ -9125,6 +11047,21 @@
 						<button type="roll" name="roll_z_humofaxius" value="@{z_humofaxius_action}"> <span>Humofaxius</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Humofaxius_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Humofaxius">
 					<input type="number" class="talent-taw" name="attr_ZfW_Humofaxius" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -9139,6 +11076,21 @@
 						<button type="roll" name="roll_z_humosphaero" value="@{z_humosphaero_action}"> <span>Humosphaero</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Humosphaero_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Humosphaero">
 					<input type="number" class="talent-taw" name="attr_ZfW_Humosphaero" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -9153,6 +11105,21 @@
 						<button type="roll" name="roll_z_ignifaxius" value="@{z_ignifaxius_action}"> <span>Ignifaxius Flammenstrahl</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_ignifaxius_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ignifaxius">
 					<input type="number" class="talent-taw" name="attr_ZfW_ignifaxius" min="0" value="0">
 					<div class="talent-cell talent-taw">122</div>
@@ -9167,6 +11134,21 @@
 						<button type="roll" name="roll_z_dz_igniflumenflammenspur" value="@{z_dz_igniflumenflammenspur_action}"> <span>Igniflumen Flammenspur</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Igniflumen_Flammenspur_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Igniflumen_Flammenspur">
 					<input type="number" class="talent-taw" name="attr_ZfW_Igniflumen_Flammenspur" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -9181,6 +11163,21 @@
 						<button type="roll" name="roll_z_ignifugo" value="@{z_ignifugo_action}"> <span>Ignifugo Feuerbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Ignifugo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Ignifugo">
 					<input type="number" class="talent-taw" name="attr_ZfW_Ignifugo" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -9195,6 +11192,21 @@
 						<button type="roll" name="roll_z_ignimorpho" value="@{z_ignimorpho_action}"> <span>Ignimorpho Feuerform</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Ignimorpho_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Ignimorpho">
 					<input type="number" class="talent-taw" name="attr_ZfW_Ignimorpho" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -9209,6 +11221,21 @@
 						<button type="roll" name="roll_z_igniplano" value="@{z_igniplano_action}"> <span>Igniplano Flächenbrand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Igniplano_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Igniplano">
 					<input type="number" class="talent-taw" name="attr_ZfW_Igniplano" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -9223,6 +11250,21 @@
 						<button type="roll" name="roll_z_dz_igniquerisfeuerkragen" value="@{z_dz_igniquerisfeuerkragen_action}"> <span>Igniqueris Feuerkragen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Igniqueris_Feuerkragen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Igniqueris_Feuerkragen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Igniqueris_Feuerkragen" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -9237,6 +11279,21 @@
 						<button type="roll" name="roll_z_ignisphaero" value="@{z_ignisphaero_action}"> <span>Ignisphaero Feuerball</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_ignisphaero_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ignisphaero">
 					<input type="number" class="talent-taw" name="attr_ZfW_ignisphaero" min="0" value="0">
 					<div class="talent-cell talent-taw">124</div>
@@ -9251,6 +11308,21 @@
 						<button type="roll" name="roll_z_ignorantia" value="@{z_ignorantia_action}"> <span>Ignorantia Ungesehn</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_ignorantia_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ignorantia">
 					<input type="number" class="talent-taw" name="attr_ZfW_ignorantia" min="0" value="0">
 					<div class="talent-cell talent-taw">125</div>
@@ -9265,6 +11337,21 @@
 						<button type="roll" name="roll_z_illusionaufloesen" value="@{z_illusionaufloesen_action}"> <span>Illusion auflösen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_illusion_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_illusion">
 					<input type="number" class="talent-taw" name="attr_ZfW_illusion" min="0" value="0">
 					<div class="talent-cell talent-taw">126</div>
@@ -9279,6 +11366,21 @@
 						<button type="roll" name="roll_z_immortalis" value="@{z_immortalis_action}"> <span>Immortalis Lebenszeit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_immortalis_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_immortalis">
 					<input type="number" class="talent-taw" name="attr_ZfW_immortalis" min="0" value="0">
 					<div class="talent-cell talent-taw">127</div>
@@ -9293,6 +11395,21 @@
 						<button type="roll" name="roll_z_imperavi" value="@{z_imperavi_action}"> <span>Imperavi Handlungszwang</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_imperavi_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_imperavi">
 					<input type="number" class="talent-taw" name="attr_ZfW_imperavi" min="0" value="0">
 					<div class="talent-cell talent-taw">128</div>
@@ -9307,6 +11424,21 @@
 						<button type="roll" name="roll_z_impersona" value="@{z_impersona_action}"> <span>Impersona Maskenbild</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Vertrautheit des Gesichtes">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_impersona_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_impersona">
 					<input type="number" class="talent-taw" name="attr_ZfW_impersona" min="0" value="0">
 					<div class="talent-cell talent-taw">129</div>
@@ -9321,6 +11453,21 @@
 						<button type="roll" name="roll_z_infinitum" value="@{z_infinitum_action}"> <span>Infinitum Immerdar</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO + <span class="abbr" title="Modifikator für die Kosten des zu verlängernden Zaubers">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_infinitum_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_infinitum">
 					<input type="number" class="talent-taw" name="attr_ZfW_infinitum" min="0" value="0">
 					<div class="talent-cell talent-taw">130</div>
@@ -9335,6 +11482,21 @@
 						<button type="roll" name="roll_z_invercano" value="@{z_invercano_action}"> <span>Invercano Spiegeltrick</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_invercano_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_invercano">
 					<input type="number" class="talent-taw" name="attr_ZfW_invercano" min="0" value="0">
 					<div class="talent-cell talent-taw">131</div>
@@ -9349,6 +11511,21 @@
 						<button type="roll" name="roll_z_invocatiomaior" value="@{z_invocatiomaior_action}"> <span>Invocatio Maior</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Dämons">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_invocatiomaior_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_invocatiomaior">
 					<input type="number" class="talent-taw" name="attr_ZfW_invocatiomaior" min="0" value="0">
 					<div class="talent-cell talent-taw">132</div>
@@ -9363,6 +11540,21 @@
 						<button type="roll" name="roll_z_invocatiominor" value="@{z_invocatiominor_action}"> <span>Invocatio Minor</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Dämons">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_invocatiominor_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_invocatiominor">
 					<input type="number" class="talent-taw" name="attr_ZfW_invocatiominor" min="0" value="0">
 					<div class="talent-cell talent-taw">133</div>
@@ -9377,6 +11569,21 @@
 						<button type="roll" name="roll_z_iribaarshand" value="@{z_iribaarshand_action}"> <span>Iribaars Hand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/IN + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_iribaars_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_iribaars">
 					<input type="number" class="talent-taw" name="attr_ZfW_iribaars" min="0" value="0">
 					<div class="talent-cell talent-taw">134</div>
@@ -9391,6 +11598,21 @@
 						<button type="roll" name="roll_z_juckreiz" value="@{z_juckreiz_action}"> <span>Juckreiz, dämlicher!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_juckreiz_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_juckreiz">
 					<input type="number" class="talent-taw" name="attr_ZfW_juckreiz" min="0" value="0">
 					<div class="talent-cell talent-taw">135</div>
@@ -9405,6 +11627,21 @@
 						<button type="roll" name="roll_z_karnifilo" value="@{z_karnifilo_action}"> <span>Karnifilo Raserei</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_karnifilo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_karnifilo">
 					<input type="number" class="talent-taw" name="attr_ZfW_karnifilo" min="0" value="0">
 					<div class="talent-cell talent-taw">136</div>
@@ -9419,6 +11656,21 @@
 						<button type="roll" name="roll_z_katzenaugen" value="@{z_katzenaugen_action}"> <span>Katzenaugen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Katzenaugen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Katzenaugen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Katzenaugen" min="0" value="0">
 					<div class="talent-cell talent-taw">137</div>
@@ -9433,6 +11685,21 @@
 						<button type="roll" name="roll_z_klarumpurum" value="@{z_klarumpurum_action}"> <span>Klarum Purum</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/CH + <span class="abbr" title="Modifikator für die Giftstufe">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_klarum_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_klarum">
 					<input type="number" class="talent-taw" name="attr_ZfW_klarum" min="0" value="0">
 					<div class="talent-cell talent-taw">138</div>
@@ -9447,6 +11714,21 @@
 						<button type="roll" name="roll_z_klickeradomms" value="@{z_klickeradomms_action}"> <span>Klickeradomms</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Klickeradomms_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Klickeradomms">
 					<input type="number" class="talent-taw" name="attr_ZfW_Klickeradomms" min="0" value="0">
 					<div class="talent-cell talent-taw">139</div>
@@ -9461,6 +11743,21 @@
 						<button type="roll" name="roll_z_koboldgeschenk" value="@{z_koboldgeschenk_action}"> <span>Koboldgeschenk</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Koboldgeschenk_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Koboldgeschenk">
 					<input type="number" class="talent-taw" name="attr_ZfW_Koboldgeschenk" min="0" value="0">
 					<div class="talent-cell talent-taw">140</div>
@@ -9475,6 +11772,21 @@
 						<button type="roll" name="roll_z_koboldovision" value="@{z_koboldovision_action}"> <span>Koboldovision</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Koboldovision_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Koboldovision">
 					<input type="number" class="talent-taw" name="attr_ZfW_Koboldovision" min="0" value="0">
 					<div class="talent-cell talent-taw">141</div>
@@ -9489,6 +11801,21 @@
 						<button type="roll" name="roll_z_kommkoboldkomm" value="@{z_kommkoboldkomm_action}"> <span>Komm Kobold Komm</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_komm_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_komm">
 					<input type="number" class="talent-taw" name="attr_ZfW_komm" min="0" value="0">
 					<div class="talent-cell talent-taw">142</div>
@@ -9503,6 +11830,21 @@
 						<button type="roll" name="roll_z_koerperlosereise" value="@{z_koerperlosereise_action}"> <span>Körperlose Reise</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_koerperlose_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_koerperlose">
 					<input type="number" class="talent-taw" name="attr_ZfW_koerperlose" min="0" value="0">
 					<div class="talent-cell talent-taw">143</div>
@@ -9517,6 +11859,21 @@
 						<button type="roll" name="roll_z_krabbelnderschrecken" value="@{z_krabbelnderschrecken_action}"> <span>Krabbelnder Schrecken</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_krabbelnder_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_krabbelnder">
 					<input type="number" class="talent-taw" name="attr_ZfW_krabbelnder" min="0" value="0">
 					<div class="talent-cell talent-taw">144</div>
@@ -9531,6 +11888,21 @@
 						<button type="roll" name="roll_z_kraftdeserzes" value="@{z_kraftdeserzes_action}"> <span>Kraft des Erzes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_kraft_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_kraft">
 					<input type="number" class="talent-taw" name="attr_ZfW_kraft" min="0" value="0">
 					<div class="talent-cell talent-taw">145</div>
@@ -9545,6 +11917,21 @@
 						<button type="roll" name="roll_z_kraftdeshumus" value="@{z_kraftdeshumus_action}"> <span>Kraft des Humus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_kraft_humus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_kraft_humus">
 					<input type="number" class="talent-taw" name="attr_ZfW_kraft_humus" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -9559,6 +11946,21 @@
 						<button type="roll" name="roll_z_kraehenruf" value="@{z_kraehenruf_action}"> <span>Krähenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_krahenruf_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_krahenruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_krahenruf" min="0" value="0">
 					<div class="talent-cell talent-taw">146</div>
@@ -9573,6 +11975,21 @@
 						<button type="roll" name="roll_z_kroetensprung" value="@{z_kroetensprung_action}"> <span>Krötensprung</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_krotensprung_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_krotensprung">
 					<input type="number" class="talent-taw" name="attr_ZfW_krotensprung" min="0" value="0">
 					<div class="talent-cell talent-taw">148</div>
@@ -9587,6 +12004,21 @@
 						<button type="roll" name="roll_z_kulminatio" value="@{z_kulminatio_action}"> <span>Kulminatio Kugelblitz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_kulminatio_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_kulminatio">
 					<input type="number" class="talent-taw" name="attr_ZfW_kulminatio" min="0" value="0">
 					<div class="talent-cell talent-taw">149</div>
@@ -9601,6 +12033,21 @@
 						<button type="roll" name="roll_z_kusch" value="@{z_kusch_action}"> <span>Kusch!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_kusch_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_kusch">
 					<input type="number" class="talent-taw" name="attr_ZfW_kusch" min="0" value="0">
 					<div class="talent-cell talent-taw">150</div>
@@ -9615,6 +12062,21 @@
 						<button type="roll" name="roll_z_lachdichgesund" value="@{z_lachdichgesund_action}"> <span>Lach dich gesund</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_lach_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_lach">
 					<input type="number" class="talent-taw" name="attr_ZfW_lach" min="0" value="0">
 					<div class="talent-cell talent-taw">151</div>
@@ -9629,6 +12091,21 @@
 						<button type="roll" name="roll_z_lachkrampf" value="@{z_lachkrampf_action}"> <span>Lachkrampf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Lachkrampf_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Lachkrampf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Lachkrampf" min="0" value="0">
 					<div class="talent-cell talent-taw">152</div>
@@ -9643,6 +12120,21 @@
 						<button type="roll" name="roll_z_langerlulatsch" value="@{z_langerlulatsch_action}"> <span>Langer Lulatsch</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/GE/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_langer_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_langer">
 					<input type="number" class="talent-taw" name="attr_ZfW_langer" min="0" value="0">
 					<div class="talent-cell talent-taw">153</div>
@@ -9657,6 +12149,21 @@
 						<button type="roll" name="roll_z_lastdesalters" value="@{z_lastdesalters_action}"> <span>Last des Alters</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_last_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_last">
 					<input type="number" class="talent-taw" name="attr_ZfW_last" min="0" value="0">
 					<div class="talent-cell talent-taw">154</div>
@@ -9671,6 +12178,21 @@
 						<button type="roll" name="roll_z_dz_leibaustausendfliegen" value="@{z_dz_leibaustausendfliegen_action}"> <span>Leib aus tausend Fliegen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Leib_aus_tausend_Fliegen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Leib_aus_tausend_Fliegen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Leib_aus_tausend_Fliegen" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -9685,6 +12207,21 @@
 						<button type="roll" name="roll_z_leibdererde" value="@{z_leibdererde_action}"> <span>Leib der Erde</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_leibdererde_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdererde">
 					<input type="number" class="talent-taw" name="attr_ZfW_leibdererde" min="0" value="0">
 					<div class="talent-cell talent-taw">155</div>
@@ -9699,6 +12236,21 @@
 						<button type="roll" name="roll_z_leibderwogen" value="@{z_leibderwogen_action}"> <span>Leib der Wogen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_leibderwogen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibderwogen">
 					<input type="number" class="talent-taw" name="attr_ZfW_leibderwogen" min="0" value="0">
 					<div class="talent-cell talent-taw">157</div>
@@ -9713,6 +12265,21 @@
 						<button type="roll" name="roll_z_leibdeseises" value="@{z_leibdeseises_action}"> <span>Leib des Eises</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_leibdeseises_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdeseises">
 					<input type="number" class="talent-taw" name="attr_ZfW_leibdeseises" min="0" value="0">
 					<div class="talent-cell talent-taw">159</div>
@@ -9727,6 +12294,21 @@
 						<button type="roll" name="roll_z_leibdeserzes" value="@{z_leibdeserzes_action}"> <span>Leib des Erzes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/GE/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_leibdeserzes_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdeserzes">
 					<input type="number" class="talent-taw" name="attr_ZfW_leibdeserzes" min="0" value="0">
 					<div class="talent-cell talent-taw">160</div>
@@ -9741,6 +12323,21 @@
 						<button type="roll" name="roll_z_leibdesfeuers" value="@{z_leibdesfeuers_action}"> <span>Leib des Feuers</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_leibdesfeuers_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdesfeuers">
 					<input type="number" class="talent-taw" name="attr_ZfW_leibdesfeuers" min="0" value="0">
 					<div class="talent-cell talent-taw">162</div>
@@ -9755,6 +12352,21 @@
 						<button type="roll" name="roll_z_leibdeswindes" value="@{z_leibdeswindes_action}"> <span>Leib des Windes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/GE/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_leibdeswindes_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_leibdeswindes">
 					<input type="number" class="talent-taw" name="attr_ZfW_leibdeswindes" min="0" value="0">
 					<div class="talent-cell talent-taw">164</div>
@@ -9769,6 +12381,21 @@
 						<button type="roll" name="roll_z_leidensbund" value="@{z_leidensbund_action}"> <span>Leidensbund</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Leidensbund_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Leidensbund">
 					<input type="number" class="talent-taw" name="attr_ZfW_Leidensbund" min="0" value="0">
 					<div class="talent-cell talent-taw">165</div>
@@ -9783,6 +12410,21 @@
 						<button type="roll" name="roll_z_levthansfeuer" value="@{z_levthansfeuer_action}"> <span>Levthans Feuer</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_levthans_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_levthans">
 					<input type="number" class="talent-taw" name="attr_ZfW_levthans" min="0" value="0">
 					<div class="talent-cell talent-taw">166</div>
@@ -9797,6 +12439,21 @@
 						<button type="roll" name="roll_z_limbusversiegeln" value="@{z_limbusversiegeln_action}"> <span>Limbus versiegeln</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_limbus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_limbus">
 					<input type="number" class="talent-taw" name="attr_ZfW_limbus" min="0" value="0">
 					<div class="talent-cell talent-taw">167</div>
@@ -9811,6 +12468,21 @@
 						<button type="roll" name="roll_z_lockruf" value="@{z_lockruf_action}"> <span>Lockruf und Feenfüße</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_lockruf_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_lockruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_lockruf" min="0" value="0">
 					<div class="talent-cell talent-taw">168</div>
@@ -9825,6 +12497,21 @@
 						<button type="roll" name="roll_z_lungedesleviatan" value="@{z_lungedesleviatan_action}"> <span>Lunge des Leviatan</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_lunge_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_lunge">
 					<input type="number" class="talent-taw" name="attr_ZfW_lunge" min="0" value="0">
 					<div class="talent-cell talent-taw">169</div>
@@ -9839,6 +12526,21 @@
 						<button type="roll" name="roll_z_madasspiegel" value="@{z_madasspiegel_action}"> <span>Madas Spiegel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_madas_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_madas">
 					<input type="number" class="talent-taw" name="attr_ZfW_madas" min="0" value="0">
 					<div class="talent-cell talent-taw">170</div>
@@ -9853,6 +12555,21 @@
 						<button type="roll" name="roll_z_magischerraub" value="@{z_magischerraub_action}"> <span>Magischer Raub</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_magischer_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_magischer">
 					<input type="number" class="talent-taw" name="attr_ZfW_magischer" min="0" value="0">
 					<div class="talent-cell talent-taw">171</div>
@@ -9867,6 +12584,21 @@
 						<button type="roll" name="roll_z_mahlstrom" value="@{z_mahlstrom_action}"> <span>Mahlstrom</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Mahlstrom_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Mahlstrom">
 					<input type="number" class="talent-taw" name="attr_ZfW_Mahlstrom" min="0" value="0">
 					<div class="talent-cell talent-taw">172</div>
@@ -9881,6 +12613,21 @@
 						<button type="roll" name="roll_z_malmkreis" value="@{z_malmkreis_action}"> <span>Malmkreis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Malmkreis_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Malmkreis">
 					<input type="number" class="talent-taw" name="attr_ZfW_Malmkreis" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -9895,6 +12642,21 @@
 						<button type="roll" name="roll_z_manifesto" value="@{z_manifesto_action}"> <span>Manifesto Element</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Komplexität der Manifestation">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_manifesto_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_manifesto">
 					<input type="number" class="talent-taw" name="attr_ZfW_manifesto" min="0" value="0">
 					<div class="talent-cell talent-taw">173</div>
@@ -9909,6 +12671,21 @@
 						<button type="roll" name="roll_z_meisterderelemente" value="@{z_meisterderelemente_action}"> <span>Meister der Elemente</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_meisterderelemente_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_meisterderelemente">
 					<input type="number" class="talent-taw" name="attr_ZfW_meisterderelemente" min="0" value="0">
 					<div class="talent-cell talent-taw">174</div>
@@ -9923,6 +12700,21 @@
 						<button type="roll" name="roll_z_meisterminderergeister" value="@{z_meisterminderergeister_action}"> <span>Meister minderer Geister</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_meisterminderergeister_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_meisterminderergeister">
 					<input type="number" class="talent-taw" name="attr_ZfW_meisterminderergeister" min="0" value="0">
 					<div class="talent-cell talent-taw">175</div>
@@ -9937,6 +12729,21 @@
 						<button type="roll" name="roll_z_memorabia" value="@{z_memorabia_action}"> <span>Memorabia Falsifir</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Dauer des getilgten Zeitabschnitts, der Zeitpunkt, ab dem getilgt werden soll, die Tiefe des Wissens und Hilfsmitteln">Mod.</span> + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_memorabia_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_memorabia">
 					<input type="number" class="talent-taw" name="attr_ZfW_memorabia" min="0" value="0">
 					<div class="talent-cell talent-taw">176</div>
@@ -9951,6 +12758,21 @@
 						<button type="roll" name="roll_z_memorans" value="@{z_memorans_action}"> <span>Memorans Gedächtniskraft</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_memorans_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_memorans">
 					<input type="number" class="talent-taw" name="attr_ZfW_memorans" min="0" value="0">
 					<div class="talent-cell talent-taw">177</div>
@@ -9965,6 +12787,21 @@
 						<button type="roll" name="roll_z_menetekel" value="@{z_menetekel_action}"> <span>Menetekel Flammenschrift</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_menetekel_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_menetekel">
 					<input type="number" class="talent-taw" name="attr_ZfW_menetekel" min="0" value="0">
 					<div class="talent-cell talent-taw">178</div>
@@ -9979,6 +12816,21 @@
 						<button type="roll" name="roll_z_metamagieneutralisieren" value="@{z_metamagieneutralisieren_action}"> <span>Metamagie neutralisieren</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_metamagie_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_metamagie">
 					<input type="number" class="talent-taw" name="attr_ZfW_metamagie" min="0" value="0">
 					<div class="talent-cell talent-taw">179</div>
@@ -9993,6 +12845,21 @@
 						<button type="roll" name="roll_z_metamorphofelsenform" value="@{z_metamorphofelsenform_action}"> <span>Metamorpho Felsenform</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_metamorpho_felsenform_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_metamorpho_felsenform">
 					<input type="number" class="talent-taw" name="attr_ZfW_metamorpho_felsenform" min="0" value="0">
 					<div class="talent-cell talent-taw">180</div>
@@ -10007,6 +12874,21 @@
 						<button type="roll" name="roll_z_metamorphogletscherform" value="@{z_metamorphogletscherform_action}"> <span>Metamorpho Gletscherform</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_metamorpho_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_metamorpho">
 					<input type="number" class="talent-taw" name="attr_ZfW_metamorpho" min="0" value="0">
 					<div class="talent-cell talent-taw">180</div>
@@ -10021,6 +12903,21 @@
 						<button type="roll" name="roll_z_motoricus" value="@{z_motoricus_action}"> <span>Motoricus Geisteshand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_motoricus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_motoricus">
 					<input type="number" class="talent-taw" name="attr_ZfW_motoricus" min="0" value="0">
 					<div class="talent-cell talent-taw">181</div>
@@ -10035,6 +12932,21 @@
 						<button type="roll" name="roll_z_movimento" value="@{z_movimento_action}"> <span>Movimento Dauerlauf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_movimento_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_movimento">
 					<input type="number" class="talent-taw" name="attr_ZfW_movimento" min="0" value="0">
 					<div class="talent-cell talent-taw">183</div>
@@ -10049,6 +12961,21 @@
 						<button type="roll" name="roll_z_murksundpatz" value="@{z_murksundpatz_action}"> <span>Murks und Patz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF + <span class="abbr" title="höchste Magieresistenz plus Anzahl Betroffener">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_murks_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_murks">
 					<input type="number" class="talent-taw" name="attr_ZfW_murks" min="0" value="0">
 					<div class="talent-cell talent-taw">184</div>
@@ -10063,6 +12990,21 @@
 						<button type="roll" name="roll_z_nackedei" value="@{z_nackedei_action}"> <span>Nackedei</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Gesamtrüstschutz des Opfers">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Nackedei_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Nackedei">
 					<input type="number" class="talent-taw" name="attr_ZfW_Nackedei" min="0" value="0">
 					<div class="talent-cell talent-taw">185</div>
@@ -10077,6 +13019,21 @@
 						<button type="roll" name="roll_z_nebelleib" value="@{z_nebelleib_action}"> <span>Nebelleib</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Nebelleib_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Nebelleib">
 					<input type="number" class="talent-taw" name="attr_ZfW_Nebelleib" min="0" value="0">
 					<div class="talent-cell talent-taw">186</div>
@@ -10091,6 +13048,21 @@
 						<button type="roll" name="roll_z_nebelwand" value="@{z_nebelwand_action}"> <span>Nebelwand und Morgendunst</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_nebelwand_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_nebelwand">
 					<input type="number" class="talent-taw" name="attr_ZfW_nebelwand" min="0" value="0">
 					<div class="talent-cell talent-taw">187</div>
@@ -10105,6 +13077,21 @@
 						<button type="roll" name="roll_z_nekropathia" value="@{z_nekropathia_action}"> <span>Nekropathia Seelenreise</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_nekropathia_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_nekropathia">
 					<input type="number" class="talent-taw" name="attr_ZfW_nekropathia" min="0" value="0">
 					<div class="talent-cell talent-taw">188</div>
@@ -10119,6 +13106,21 @@
 						<button type="roll" name="roll_z_nihilogravo" value="@{z_nihilogravo_action}"> <span>Nihilogravo Schwerelos</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_nihilogravo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_nihilogravo">
 					<input type="number" class="talent-taw" name="attr_ZfW_nihilogravo" min="0" value="0">
 					<div class="talent-cell talent-taw">189</div>
@@ -10133,6 +13135,21 @@
 						<button type="roll" name="roll_z_nuntiovolo" value="@{z_nuntiovolo_action}"> <span>Nuntiovolo Botenvogel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_nuntiovolo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_nuntiovolo">
 					<input type="number" class="talent-taw" name="attr_ZfW_nuntiovolo" min="0" value="0">
 					<div class="talent-cell talent-taw">190</div>
@@ -10147,6 +13164,21 @@
 						<button type="roll" name="roll_z_objectoobscuro" value="@{z_objectoobscuro_action}"> <span>Objecto Obscuro</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_objecto_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_objecto">
 					<input type="number" class="talent-taw" name="attr_ZfW_objecto" min="0" value="0">
 					<div class="talent-cell talent-taw">191</div>
@@ -10161,6 +13193,21 @@
 						<button type="roll" name="roll_z_objectofixo" value="@{z_objectofixo_action}"> <span>Objectofixo</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Objectofixo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Objectofixo">
 					<input type="number" class="talent-taw" name="attr_ZfW_Objectofixo" min="0" value="0">
 					<div class="talent-cell talent-taw">192</div>
@@ -10175,6 +13222,21 @@
 						<button type="roll" name="roll_z_objectovoco" value="@{z_objectovoco_action}"> <span>Objectovoco</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_objectovoco_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_objectovoco">
 					<input type="number" class="talent-taw" name="attr_ZfW_objectovoco" min="0" value="0">
 					<div class="talent-cell talent-taw">193</div>
@@ -10189,6 +13251,21 @@
 						<button type="roll" name="roll_z_objektentzaubern" value="@{z_objektentzaubern_action}"> <span>Objekt entzaubern</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_objekt_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_objekt">
 					<input type="number" class="talent-taw" name="attr_ZfW_objekt" min="0" value="0">
 					<div class="talent-cell talent-taw">194</div>
@@ -10203,6 +13280,21 @@
 						<button type="roll" name="roll_z_oculus" value="@{z_oculus_action}"> <span>Oculus Astralis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_oculus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_oculus">
 					<input type="number" class="talent-taw" name="attr_ZfW_oculus" min="0" value="0">
 					<div class="talent-cell talent-taw">196</div>
@@ -10217,6 +13309,21 @@
 						<button type="roll" name="roll_z_odem" value="@{z_odem_action}"> <span>Odem Arcanum</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/IN + <span class="abbr" title="Modifikator für die im Zielobjekt permanent gebundenen Astralpunkte, dem Astralenergievorrat des Zielwesens, der Zeit seit dem Vergehen des Zaubers oder der Art des magischen Wesens">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_odem_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_odem">
 					<input type="number" class="talent-taw" name="attr_ZfW_odem" min="0" value="0">
 					<div class="talent-cell talent-taw">197</div>
@@ -10231,6 +13338,21 @@
 						<button type="roll" name="roll_z_orcanofaxius" value="@{z_orcanofaxius_action}"> <span>Orcanofaxius</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Orcanofaxius_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Orcanofaxius">
 					<input type="number" class="talent-taw" name="attr_ZfW_Orcanofaxius" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -10245,6 +13367,21 @@
 						<button type="roll" name="roll_z_orcanosphaero" value="@{z_orcanosphaero_action}"> <span>Orcanosphaero</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Orcanosphaero_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Orcanosphaero">
 					<input type="number" class="talent-taw" name="attr_ZfW_Orcanosphaero" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -10259,6 +13396,21 @@
 						<button type="roll" name="roll_z_pandaemonium" value="@{z_pandaemonium_action}"> <span>Pandaemonium</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Größe des dämonenverseuchten Gebiets">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Pandaemonium_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Pandaemonium">
 					<input type="number" class="talent-taw" name="attr_ZfW_Pandaemonium" min="0" value="0">
 					<div class="talent-cell talent-taw">199</div>
@@ -10273,6 +13425,21 @@
 						<button type="roll" name="roll_z_panik" value="@{z_panik_action}"> <span>Panik überkomme euch!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_panik_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_panik">
 					<input type="number" class="talent-taw" name="attr_ZfW_panik" min="0" value="0">
 					<div class="talent-cell talent-taw">200</div>
@@ -10287,6 +13454,21 @@
 						<button type="roll" name="roll_z_papperlapapp" value="@{z_papperlapapp_action}"> <span>Papperlapapp</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Papperlapapp_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Papperlapapp">
 					<input type="number" class="talent-taw" name="attr_ZfW_Papperlapapp" min="0" value="0">
 					<div class="talent-cell talent-taw">201</div>
@@ -10301,6 +13483,21 @@
 						<button type="roll" name="roll_z_paralysis" value="@{z_paralysis_action}"> <span>Paralysis starr wie Stein</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_paralys_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_paralys">
 					<input type="number" class="talent-taw" name="attr_ZfW_paralys" min="0" value="0">
 					<div class="talent-cell talent-taw">202</div>
@@ -10315,6 +13512,21 @@
 						<button type="roll" name="roll_z_pectetondo" value="@{z_pectetondo_action}"> <span>Pectetondo Zauberhaar</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pectetondo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pectetondo">
 					<input type="number" class="talent-taw" name="attr_ZfW_pectetondo" min="0" value="0">
 					<div class="talent-cell talent-taw">203</div>
@@ -10329,6 +13541,21 @@
 						<button type="roll" name="roll_z_penetrizzel" value="@{z_penetrizzel_action}"> <span>Penetrizzel Tiefenblick</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_penetrizzel_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_penetrizzel">
 					<input type="number" class="talent-taw" name="attr_ZfW_penetrizzel" min="0" value="0">
 					<div class="talent-cell talent-taw">204</div>
@@ -10343,6 +13570,21 @@
 						<button type="roll" name="roll_z_pentagramma" value="@{z_pentagramma_action}"> <span>Pentagramma Sphärenbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit, die Art des Wesens, bestimmter dämonischer Eigenheiten, Kenntnis des wahren Namens, Bannschwert, korrekte Bekleidung und passende Donaria">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pentagramma_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pentagramma">
 					<input type="number" class="talent-taw" name="attr_ZfW_pentagramma" min="0" value="0">
 					<div class="talent-cell talent-taw">205</div>
@@ -10357,6 +13599,21 @@
 						<button type="roll" name="roll_z_pestilenzerspueren" value="@{z_pestilenzerspueren_action}"> <span>Pestilenz erspüren</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Entdeckungsschwierigkeit der Krankheit oder der Giftstufe des Giftes">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pestilenz_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pestilenz">
 					<input type="number" class="talent-taw" name="attr_ZfW_pestilenz" min="0" value="0">
 					<div class="talent-cell talent-taw">207</div>
@@ -10371,6 +13628,21 @@
 						<button type="roll" name="roll_z_pfeilderluft" value="@{z_pfeilderluft_action}"> <span>Pfeil der Luft</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pfeilderluft_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeilderluft">
 					<input type="number" class="talent-taw" name="attr_ZfW_pfeilderluft" min="0" value="0">
 					<div class="talent-cell talent-taw">208</div>
@@ -10385,6 +13657,21 @@
 						<button type="roll" name="roll_z_pfeildeseises" value="@{z_pfeildeseises_action}"> <span>Pfeil des Eises</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pfeildeseises_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildeseises">
 					<input type="number" class="talent-taw" name="attr_ZfW_pfeildeseises" min="0" value="0">
 					<div class="talent-cell talent-taw">208</div>
@@ -10399,6 +13686,21 @@
 						<button type="roll" name="roll_z_pfeildeserzes" value="@{z_pfeildeserzes_action}"> <span>Pfeil des Erzes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pfeildeserzes_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildeserzes">
 					<input type="number" class="talent-taw" name="attr_ZfW_pfeildeserzes" min="0" value="0">
 					<div class="talent-cell talent-taw">208</div>
@@ -10413,6 +13715,21 @@
 						<button type="roll" name="roll_z_pfeildesfeuers" value="@{z_pfeildesfeuers_action}"> <span>Pfeil des Feuers</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pfeildesfeuers_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildesfeuers">
 					<input type="number" class="talent-taw" name="attr_ZfW_pfeildesfeuers" min="0" value="0">
 					<div class="talent-cell talent-taw">208</div>
@@ -10427,6 +13744,21 @@
 						<button type="roll" name="roll_z_pfeildeshumus" value="@{z_pfeildeshumus_action}"> <span>Pfeil des Humus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pfeildeshumus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildeshumus">
 					<input type="number" class="talent-taw" name="attr_ZfW_pfeildeshumus" min="0" value="0">
 					<div class="talent-cell talent-taw">208</div>
@@ -10441,6 +13773,21 @@
 						<button type="roll" name="roll_z_pfeildeswassers" value="@{z_pfeildeswassers_action}"> <span>Pfeil des Wassers</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_pfeildeswassers_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_pfeildeswassers">
 					<input type="number" class="talent-taw" name="attr_ZfW_pfeildeswassers" min="0" value="0">
 					<div class="talent-cell talent-taw">208</div>
@@ -10455,6 +13802,21 @@
 						<button type="roll" name="roll_z_planastrale" value="@{z_planastrale_action}"> <span>Planastrale Anderswelt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_planastrale_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_planastrale">
 					<input type="number" class="talent-taw" name="attr_ZfW_planastrale" min="0" value="0">
 					<div class="talent-cell talent-taw">210</div>
@@ -10469,6 +13831,21 @@
 						<button type="roll" name="roll_z_plumbumbarum" value="@{z_plumbumbarum_action}"> <span>Plumbumbarum schwerer Arm</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/GE/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_plumbumbarum_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_plumbumbarum">
 					<input type="number" class="talent-taw" name="attr_ZfW_plumbumbarum" min="0" value="0">
 					<div class="talent-cell talent-taw">211</div>
@@ -10483,6 +13860,21 @@
 						<button type="roll" name="roll_z_projektimago" value="@{z_projektimago_action}"> <span>Projektimago Ebenbild</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Entfernung zwischen Magier und Projektion">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_projektimago_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_projektimago">
 					<input type="number" class="talent-taw" name="attr_ZfW_projektimago" min="0" value="0">
 					<div class="talent-cell talent-taw">212</div>
@@ -10497,6 +13889,21 @@
 						<button type="roll" name="roll_z_protectionis" value="@{z_protectionis_action}"> <span>Protectionis Kontrabann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_protectionis_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_protectionis">
 					<input type="number" class="talent-taw" name="attr_ZfW_protectionis" min="0" value="0">
 					<div class="talent-cell talent-taw">213</div>
@@ -10511,6 +13918,21 @@
 						<button type="roll" name="roll_z_psychostabilis" value="@{z_psychostabilis_action}"> <span>Psychostabilis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_psychostabilis_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_psychostabilis">
 					<input type="number" class="talent-taw" name="attr_ZfW_psychostabilis" min="0" value="0">
 					<div class="talent-cell talent-taw">214</div>
@@ -10525,6 +13947,21 @@
 						<button type="roll" name="roll_z_radau" value="@{z_radau_action}"> <span>Radau</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_radau_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_radau">
 					<input type="number" class="talent-taw" name="attr_ZfW_radau" min="0" value="0">
 					<div class="talent-cell talent-taw">215</div>
@@ -10539,6 +13976,21 @@
 						<button type="roll" name="roll_z_reflectimago" value="@{z_reflectimago_action}"> <span>Reflectimago Spiegelschein</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_reflectimago_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_reflectimago">
 					<input type="number" class="talent-taw" name="attr_ZfW_reflectimago" min="0" value="0">
 					<div class="talent-cell talent-taw">216</div>
@@ -10553,6 +14005,21 @@
 						<button type="roll" name="roll_z_reptilea" value="@{z_reptilea_action}"> <span>Reptilia Natternnest</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_reptilea_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_reptilea">
 					<input type="number" class="talent-taw" name="attr_ZfW_reptilea" min="0" value="0">
 					<div class="talent-cell talent-taw">217</div>
@@ -10567,6 +14034,21 @@
 						<button type="roll" name="roll_z_respondami" value="@{z_respondami_action}"> <span>Respondami Wahrheitszwang</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_respondami_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_respondami">
 					<input type="number" class="talent-taw" name="attr_ZfW_respondami" min="0" value="0">
 					<div class="talent-cell talent-taw">218</div>
@@ -10581,6 +14063,21 @@
 						<button type="roll" name="roll_z_reversalis" value="@{z_reversalis_action}"> <span>Reversalis Revidum</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_reversalis_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_reversalis">
 					<input type="number" class="talent-taw" name="attr_ZfW_reversalis" min="0" value="0">
 					<div class="talent-cell talent-taw">219</div>
@@ -10595,6 +14092,21 @@
 						<button type="roll" name="roll_z_ruhekoerper" value="@{z_ruhekoerper_action}"> <span>Ruhe Körper, Ruhe Geist</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_ruhe_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_ruhe">
 					<input type="number" class="talent-taw" name="attr_ZfW_ruhe" min="0" value="0">
 					<div class="talent-cell talent-taw">220</div>
@@ -10609,6 +14121,21 @@
 						<button type="roll" name="roll_z_salander" value="@{z_salander_action}"> <span>Salander Mutander</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_salander_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_salander">
 					<input type="number" class="talent-taw" name="attr_ZfW_salander" min="0" value="0">
 					<div class="talent-cell talent-taw">221</div>
@@ -10623,6 +14150,21 @@
 						<button type="roll" name="roll_z_sanftmut" value="@{z_sanftmut_action}"> <span>Sanftmut</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Sanftmut_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Sanftmut">
 					<input type="number" class="talent-taw" name="attr_ZfW_Sanftmut" min="0" value="0">
 					<div class="talent-cell talent-taw">222</div>
@@ -10637,6 +14179,21 @@
 						<button type="roll" name="roll_z_sapefacta" value="@{z_sapefacta_action}"> <span>Sapefacta Zauberschwamm</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_sapefacta_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sapefacta">
 					<input type="number" class="talent-taw" name="attr_ZfW_sapefacta" min="0" value="0">
 					<div class="talent-cell talent-taw">223</div>
@@ -10651,6 +14208,21 @@
 						<button type="roll" name="roll_z_satuariasherrlichkeit" value="@{z_satuariasherrlichkeit_action}"> <span>Satuarias Herrlichkeit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_satuarias_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_satuarias">
 					<input type="number" class="talent-taw" name="attr_ZfW_satuarias" min="0" value="0">
 					<div class="talent-cell talent-taw">224</div>
@@ -10665,6 +14237,21 @@
 						<button type="roll" name="roll_z_schabernack" value="@{z_schabernack_action}"> <span>Schabernack</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Schabernack_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schabernack">
 					<input type="number" class="talent-taw" name="attr_ZfW_Schabernack" min="0" value="0">
 					<div class="talent-cell talent-taw">225</div>
@@ -10679,6 +14266,21 @@
 						<button type="roll" name="roll_z_schadenszauberbannen" value="@{z_schadenszauberbannen_action}"> <span>Schadenszauber bannen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_schadenszauber_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_schadenszauber">
 					<input type="number" class="talent-taw" name="attr_ZfW_schadenszauber" min="0" value="0">
 					<div class="talent-cell talent-taw">226</div>
@@ -10693,6 +14295,21 @@
 						<button type="roll" name="roll_z_schelmenkleister" value="@{z_schelmenkleister_action}"> <span>Schelmenkleister</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Schelmenkleister_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schelmenkleister">
 					<input type="number" class="talent-taw" name="attr_ZfW_Schelmenkleister" min="0" value="0">
 					<div class="talent-cell talent-taw">227</div>
@@ -10707,6 +14324,21 @@
 						<button type="roll" name="roll_z_schelmenlaune" value="@{z_schelmenlaune_action}"> <span>Schelmenlaune</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Höchste Magieresistenz + Zahl der Betroffenen + Stärke des Stimmungsumschwungs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Schelmenlaune_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schelmenlaune">
 					<input type="number" class="talent-taw" name="attr_ZfW_Schelmenlaune" min="0" value="0">
 					<div class="talent-cell talent-taw">228</div>
@@ -10721,6 +14353,21 @@
 						<button type="roll" name="roll_z_schelmenmaske" value="@{z_schelmenmaske_action}"> <span>Schelmenmaske</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Schelmenmaske_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schelmenmaske">
 					<input type="number" class="talent-taw" name="attr_ZfW_Schelmenmaske" min="0" value="0">
 					<div class="talent-cell talent-taw">229</div>
@@ -10735,6 +14382,21 @@
 						<button type="roll" name="roll_z_schelmenrausch" value="@{z_schelmenrausch_action}"> <span>Schelmenrausch</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Schelmenrausch_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Schelmenrausch">
 					<input type="number" class="talent-taw" name="attr_ZfW_Schelmenrausch" min="0" value="0">
 					<div class="talent-cell talent-taw">230</div>
@@ -10749,6 +14411,21 @@
 						<button type="roll" name="roll_z_dz_schlangenruf" value="@{z_dz_schlangenruf_action}"> <span>Schlangenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Schlangenruf_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Schlangenruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Schlangenruf" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -10763,6 +14440,21 @@
 						<button type="roll" name="roll_z_schleierderunwissenheit" value="@{z_schleierderunwissenheit_action}"> <span>Schleier der Unwissenheit</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_schleier_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_schleier">
 					<input type="number" class="talent-taw" name="attr_ZfW_schleier" min="0" value="0">
 					<div class="talent-cell talent-taw">231</div>
@@ -10777,6 +14469,21 @@
 						<button type="roll" name="roll_z_schwarzundrot" value="@{z_schwarzundrot_action}"> <span>Schwarz und Rot</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_schwarzundrot_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_schwarzundrot">
 					<input type="number" class="talent-taw" name="attr_ZfW_schwarzundrot" min="0" value="0">
 					<div class="talent-cell talent-taw">232</div>
@@ -10791,6 +14498,21 @@
 						<button type="roll" name="roll_z_schwarzerschrecken" value="@{z_schwarzerschrecken_action}"> <span>Schwarzer Schrecken</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_schwarzerschrecken_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_schwarzerschrecken">
 					<input type="number" class="talent-taw" name="attr_ZfW_schwarzerschrecken" min="0" value="0">
 					<div class="talent-cell talent-taw">233</div>
@@ -10805,6 +14527,21 @@
 						<button type="roll" name="roll_z_dz_seelenfeuerlichterloh" value="@{z_dz_seelenfeuerlichterloh_action}"> <span>Seelenfeuer Lichterloh</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Seelenfeuer_Lichterloh_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Seelenfeuer_Lichterloh">
 					<input type="number" class="talent-taw" name="attr_ZfW_Seelenfeuer_Lichterloh" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -10819,6 +14556,21 @@
 						<button type="roll" name="roll_z_seelentiererkennen" value="@{z_seelentiererkennen_action}"> <span>Seelentier erkennen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_seelentier_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_seelentier">
 					<input type="number" class="talent-taw" name="attr_ZfW_seelentier" min="0" value="0">
 					<div class="talent-cell talent-taw">234</div>
@@ -10833,6 +14585,21 @@
 						<button type="roll" name="roll_z_seelenwanderung" value="@{z_seelenwanderung_action}"> <span>Seelenwanderung</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Doppelte Magieresistenz, mindestens aber 7">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_seelenwanderung_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_seelenwanderung">
 					<input type="number" class="talent-taw" name="attr_ZfW_seelenwanderung" min="0" value="0">
 					<div class="talent-cell talent-taw">235</div>
@@ -10847,6 +14614,21 @@
 						<button type="roll" name="roll_z_seidenweich" value="@{z_seidenweich_action}"> <span>Seidenweich Schuppengleich</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_seidenweich_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_seidenweich">
 					<input type="number" class="talent-taw" name="attr_ZfW_seidenweich" min="0" value="0">
 					<div class="talent-cell talent-taw">236</div>
@@ -10861,6 +14643,21 @@
 						<button type="roll" name="roll_z_seidenzunge" value="@{z_seidenzunge_action}"> <span>Seidenzunge Elfenwort</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_seidenzunge_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_seidenzunge">
 					<input type="number" class="talent-taw" name="attr_ZfW_seidenzunge" min="0" value="0">
 					<div class="talent-cell talent-taw">237</div>
@@ -10875,6 +14672,21 @@
 						<button type="roll" name="roll_z_sensattacco" value="@{z_sensattacco_action}"> <span>Sensattacco Meisterstreich</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_sensattacco_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sensattacco">
 					<input type="number" class="talent-taw" name="attr_ZfW_sensattacco" min="0" value="0">
 					<div class="talent-cell talent-taw">238</div>
@@ -10889,6 +14701,21 @@
 						<button type="roll" name="roll_z_sensibar" value="@{z_sensibar_action}"> <span>Sensibar Empathicus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_sensibar_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sensibar">
 					<input type="number" class="talent-taw" name="attr_ZfW_sensibar" min="0" value="0">
 					<div class="talent-cell talent-taw">239</div>
@@ -10903,6 +14730,21 @@
 						<button type="roll" name="roll_z_serpentialis" value="@{z_serpentialis_action}"> <span>Serpentialis Schlangenleib</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_serpentialis_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_serpentialis">
 					<input type="number" class="talent-taw" name="attr_ZfW_serpentialis" min="0" value="0">
 					<div class="talent-cell talent-taw">240</div>
@@ -10917,6 +14759,21 @@
 						<button type="roll" name="roll_z_silentium" value="@{z_silentium_action}"> <span>Silentium Schweigekreis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_silentium_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_silentium">
 					<input type="number" class="talent-taw" name="attr_ZfW_silentium" min="0" value="0">
 					<div class="talent-cell talent-taw">241</div>
@@ -10931,6 +14788,21 @@
 						<button type="roll" name="roll_z_sinesigil" value="@{z_sinesigil_action}"> <span>Sinesigil unerkannt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_sinesigil_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sinesigil">
 					<input type="number" class="talent-taw" name="attr_ZfW_sinesigil" min="0" value="0">
 					<div class="talent-cell talent-taw">242</div>
@@ -10945,6 +14817,21 @@
 						<button type="roll" name="roll_z_skelettarius" value="@{z_skelettarius_action}"> <span>Skelettarius Totenherr</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Untoten">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_skelettarius_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_skelettarius">
 					<input type="number" class="talent-taw" name="attr_ZfW_skelettarius" min="0" value="0">
 					<div class="talent-cell talent-taw">243</div>
@@ -10959,6 +14846,21 @@
 						<button type="roll" name="roll_z_solidirid" value="@{z_solidirid_action}"> <span>Solidirid Weg aus Licht</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/KO/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_solidirid_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_solidirid">
 					<input type="number" class="talent-taw" name="attr_ZfW_solidirid" min="0" value="0">
 					<div class="talent-cell talent-taw">245</div>
@@ -10973,6 +14875,21 @@
 						<button type="roll" name="roll_z_somnigravis" value="@{z_somnigravis_action}"> <span>Somnigravis tiefer Schlaf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_somnigravis_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_somnigravis">
 					<input type="number" class="talent-taw" name="attr_ZfW_somnigravis" min="0" value="0">
 					<div class="talent-cell talent-taw">246</div>
@@ -10987,6 +14904,21 @@
 						<button type="roll" name="roll_z_dz_sphaerovisioschreckensbild" value="@{z_dz_sphaerovisioschreckensbild_action}"> <span>Sphaerovisio Schreckensbild</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Sphaerovisio_Schreckensbild_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Sphaerovisio_Schreckensbild">
 					<input type="number" class="talent-taw" name="attr_ZfW_Sphaerovisio_Schreckensbild" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -11001,6 +14933,21 @@
 						<button type="roll" name="roll_z_spinnenlauf" value="@{z_spinnenlauf_action}"> <span>Spinnenlauf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_spinnenlauf_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_spinnenlauf">
 					<input type="number" class="talent-taw" name="attr_ZfW_spinnenlauf" min="0" value="0">
 					<div class="talent-cell talent-taw">247</div>
@@ -11015,6 +14962,21 @@
 						<button type="roll" name="roll_z_dz_spinnennetz" value="@{z_dz_spinnennetz_action}"> <span>Spinnennetz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Spinnennetz_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Spinnennetz">
 					<input type="number" class="talent-taw" name="attr_ZfW_Spinnennetz" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -11029,6 +14991,21 @@
 						<button type="roll" name="roll_z_dz_spinnenruf" value="@{z_dz_spinnenruf_action}"> <span>Spinnenruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Spinnenruf_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Spinnenruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Spinnenruf" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -11043,6 +15020,21 @@
 						<button type="roll" name="roll_z_spurlos" value="@{z_spurlos_action}"> <span>Spurlos Trittlos</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_spurlos_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_spurlos">
 					<input type="number" class="talent-taw" name="attr_ZfW_spurlos" min="0" value="0">
 					<div class="talent-cell talent-taw">248</div>
@@ -11057,6 +15049,21 @@
 						<button type="roll" name="roll_z_standfest" value="@{z_standfest_action}"> <span>Standfest Katzengleich</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_standfest_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_standfest">
 					<input type="number" class="talent-taw" name="attr_ZfW_standfest" min="0" value="0">
 					<div class="talent-cell talent-taw">249</div>
@@ -11071,6 +15078,21 @@
 						<button type="roll" name="roll_z_staubwandle" value="@{z_staubwandle_action}"> <span>Staub wandle!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die handwerkliche Qualität des unbelebten Golemids, das Grundmaterial, die elementare Reinheit des Ausgangsmaterials, der Größe des Golemids, der Eigenschaften des Golemids, die Anzahl weiterer Dienste, die besonderen Fähigkeiten des Golemids und die Talentwerte des Golemids">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_staub_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_staub">
 					<input type="number" class="talent-taw" name="attr_ZfW_staub" min="0" value="0">
 					<div class="talent-cell talent-taw">250</div>
@@ -11085,6 +15107,21 @@
 						<button type="roll" name="roll_z_steinmauer" value="@{z_steinmauer_action}"> <span>Steinmauer</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Steinmauer_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Steinmauer">
 					<input type="number" class="talent-taw" name="attr_ZfW_Steinmauer" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -11099,6 +15136,21 @@
 						<button type="roll" name="roll_z_steinwandle" value="@{z_steinwandle_action}"> <span>Stein wandle!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KK + <span class="abbr" title="Modifikator für die handwerkliche Qualität des unbelebten Golems, das Grundmaterial, die Affinität des Materials zum Erzdämonen, der Größe des Golems, der Eigenschaften des Golems, die Anzahl weiterer Dienste, die besonderen Fähigkeiten des Golems und die Talentwerte des Golems">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_stein_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_stein">
 					<input type="number" class="talent-taw" name="attr_ZfW_stein" min="0" value="0">
 					<div class="talent-cell talent-taw">251</div>
@@ -11113,6 +15165,21 @@
 						<button type="roll" name="roll_z_stillstand" value="@{z_stillstand_action}"> <span>Stillstand</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_stillstand_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_stillstand">
 					<input type="number" class="talent-taw" name="attr_ZfW_stillstand" min="0" value="0">
 					<div class="talent-cell talent-taw">252</div>
@@ -11127,6 +15194,21 @@
 						<button type="roll" name="roll_z_stimmendeswindes" value="@{z_stimmendeswindes_action}"> <span>Stimmen des Windes</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Stimmen_des_Windes_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Stimmen_des_Windes">
 					<input type="number" class="talent-taw" name="attr_ZfW_Stimmen_des_Windes" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -11141,6 +15223,21 @@
 						<button type="roll" name="roll_z_sumpfstrudel" value="@{z_sumpfstrudel_action}"> <span>Sumpfstrudel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Sumpfstrudel_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Sumpfstrudel">
 					<input type="number" class="talent-taw" name="attr_ZfW_Sumpfstrudel" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -11155,6 +15252,21 @@
 						<button type="roll" name="roll_z_sumuselixiere" value="@{z_sumuselixiere_action}"> <span>Sumus Elixiere</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_sumus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_sumus">
 					<input type="number" class="talent-taw" name="attr_ZfW_sumus" min="0" value="0">
 					<div class="talent-cell talent-taw">253</div>
@@ -11169,6 +15281,21 @@
 						<button type="roll" name="roll_z_dz_tanzdererloesung" value="@{z_dz_tanzdererloesung_action}"> <span>Tanz der Erlösung</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Anzahl der wirkenden Sprüche mit den Merkmalen &bdquo;Einfluss&ldquo; oder &bdquo;Herrschaft&ldquo; + Höchste ZfP* der wirkenden Sprüche mit den Merkmalen &bdquo;Einfluss&ldquo; oder &bdquo;Herrschaft&ldquo;">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Tanz_der_Erloesung_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Tanz_der_Erloesung">
 					<input type="number" class="talent-taw" name="attr_ZfW_Tanz_der_Erloesung" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -11183,6 +15310,21 @@
 						<button type="roll" name="roll_z_tauschrausch" value="@{z_tauschrausch_action}"> <span>Tauschrausch</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_tauschrausch_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tauschrausch">
 					<input type="number" class="talent-taw" name="attr_ZfW_tauschrausch" min="0" value="0">
 					<div class="talent-cell talent-taw">254</div>
@@ -11197,6 +15339,21 @@
 						<button type="roll" name="roll_z_tempusstasis" value="@{z_tempusstasis_action}"> <span>Tempus Stasis</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK + <span class="abbr" title="1 pro Kampfrunde">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_tempus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tempus">
 					<input type="number" class="talent-taw" name="attr_ZfW_tempus" min="0" value="0">
 					<div class="talent-cell talent-taw">255</div>
@@ -11211,6 +15368,21 @@
 						<button type="roll" name="roll_z_dz_thargunitothbann" value="@{z_dz_thargunitothbann_action}"> <span>Thargunitothbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Thargunitothbann_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Thargunitothbann">
 					<input type="number" class="talent-taw" name="attr_ZfW_Thargunitothbann" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -11225,6 +15397,21 @@
 						<button type="roll" name="roll_z_tierebesprechen" value="@{z_tierebesprechen_action}"> <span>Tiere besprechen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Anzahl zu heilender regeltechnischer Wunden, der Stufe der Krankheit oder der halben Giftstufe">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_tiere_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tiere">
 					<input type="number" class="talent-taw" name="attr_ZfW_tiere" min="0" value="0">
 					<div class="talent-cell talent-taw">256</div>
@@ -11239,6 +15426,21 @@
 						<button type="roll" name="roll_z_tiergedanken" value="@{z_tiergedanken_action}"> <span>Tiergedanken</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_tiergedanken_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tiergedanken">
 					<input type="number" class="talent-taw" name="attr_ZfW_tiergedanken" min="0" value="0">
 					<div class="talent-cell talent-taw">257</div>
@@ -11253,6 +15455,21 @@
 						<button type="roll" name="roll_z_dz_tierruf" value="@{z_dz_tierruf_action}"> <span>Tierruf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Tierruf_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Tierruf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Tierruf" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -11267,6 +15484,21 @@
 						<button type="roll" name="roll_z_tlalucsodem" value="@{z_tlalucsodem_action}"> <span>Tlalucs Odem Pestgestank</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_tlalucs_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_tlalucs">
 					<input type="number" class="talent-taw" name="attr_ZfW_tlalucs" min="0" value="0">
 					<div class="talent-cell talent-taw">258</div>
@@ -11281,6 +15513,21 @@
 						<button type="roll" name="roll_z_toteshandle" value="@{z_toteshandle_action}"> <span>Totes Handle!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Untoten">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_totes_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_totes">
 					<input type="number" class="talent-taw" name="attr_ZfW_totes" min="0" value="0">
 					<div class="talent-cell talent-taw">259</div>
@@ -11295,6 +15542,21 @@
 						<button type="roll" name="roll_z_transformatio" value="@{z_transformatio_action}"> <span>Transformatio Formgestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK + <span class="abbr" title="Modifikator für die Veränderung der Materialqualität, die Veränderungen von Volumen oder Masse und der Veränderung von Form und Struktur">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_transformatio_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_transformatio">
 					<input type="number" class="talent-taw" name="attr_ZfW_transformatio" min="0" value="0">
 					<div class="talent-cell talent-taw">260</div>
@@ -11309,6 +15571,21 @@
 						<button type="roll" name="roll_z_transmutare" value="@{z_transmutare_action}"> <span>Transmutare Körperform</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/GE/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_transmutare_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_transmutare">
 					<input type="number" class="talent-taw" name="attr_ZfW_transmutare" min="0" value="0">
 					<div class="talent-cell talent-taw">261</div>
@@ -11323,6 +15600,21 @@
 						<button type="roll" name="roll_z_transversalis" value="@{z_transversalis_action}"> <span>Transversalis Teleport</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_transversalis_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_transversalis">
 					<input type="number" class="talent-taw" name="attr_ZfW_transversalis" min="0" value="0">
 					<div class="talent-cell talent-taw">262</div>
@@ -11337,6 +15629,21 @@
 						<button type="roll" name="roll_z_traumgestalt" value="@{z_traumgestalt_action}"> <span>Traumgestalt</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Traumgestalt_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Traumgestalt">
 					<input type="number" class="talent-taw" name="attr_ZfW_Traumgestalt" min="0" value="0">
 					<div class="talent-cell talent-taw">263</div>
@@ -11351,6 +15658,21 @@
 						<button type="roll" name="roll_z_umbraporta" value="@{z_umbraporta_action}"> <span>Umbraporta Schattentür</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Umbraporta_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Umbraporta">
 					<input type="number" class="talent-taw" name="attr_ZfW_Umbraporta" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -11365,6 +15687,21 @@
 						<button type="roll" name="roll_z_unberuehrt" value="@{z_unberuehrt_action}"> <span>Unberührt von Satinav</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO + <span class="abbr" title="1 pro Tag Wirkungsdauer über den ersten hinaus">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_unberuhrt_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_unberuhrt">
 					<input type="number" class="talent-taw" name="attr_ZfW_unberuhrt" min="0" value="0">
 					<div class="talent-cell talent-taw">264</div>
@@ -11379,6 +15716,21 @@
 						<button type="roll" name="roll_z_unitatio" value="@{z_unitatio_action}"> <span>Unitatio Geistesbund</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_unitatio_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_unitatio">
 					<input type="number" class="talent-taw" name="attr_ZfW_unitatio" min="0" value="0">
 					<div class="talent-cell talent-taw">265</div>
@@ -11393,6 +15745,21 @@
 						<button type="roll" name="roll_z_dz_unsichtbareglut" value="@{z_dz_unsichtbareglut_action}"> <span>Unsichtbare Glut</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Unsichtbare_Glut_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Unsichtbare_Glut">
 					<input type="number" class="talent-taw" name="attr_ZfW_Unsichtbare_Glut" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -11407,6 +15774,21 @@
 						<button type="roll" name="roll_z_unsichtbarerjaeger" value="@{z_unsichtbarerjaeger_action}"> <span>Unsichtbarer Jäger</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_unsichtbarer_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_unsichtbarer">
 					<input type="number" class="talent-taw" name="attr_ZfW_unsichtbarer" min="0" value="0">
 					<div class="talent-cell talent-taw">266</div>
@@ -11421,6 +15803,21 @@
 						<button type="roll" name="roll_z_dz_valetudolebenskraft" value="@{z_dz_valetudolebenskraft_action}"> <span>Valetudo Lebenskraft</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Valetudo_Lebenskraft_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Valetudo_Lebenskraft">
 					<input type="number" class="talent-taw" name="attr_ZfW_Valetudo_Lebenskraft" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -11435,6 +15832,21 @@
 						<button type="roll" name="roll_z_veraenderungaufheben" value="@{z_veraenderungaufheben_action}"> <span>Veränderung aufheben</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_veranderung_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_veranderung">
 					<input type="number" class="talent-taw" name="attr_ZfW_veranderung" min="0" value="0">
 					<div class="talent-cell talent-taw">267</div>
@@ -11449,6 +15861,21 @@
 						<button type="roll" name="roll_z_verschwindibus" value="@{z_verschwindibus_action}"> <span>Verschwindibus</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_verschwindibus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_verschwindibus">
 					<input type="number" class="talent-taw" name="attr_ZfW_verschwindibus" min="0" value="0">
 					<div class="talent-cell talent-taw">268</div>
@@ -11463,6 +15890,21 @@
 						<button type="roll" name="roll_z_verstaendigungstoeren" value="@{z_verstaendigungstoeren_action}"> <span>Verständigung stören</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_verstandigung_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_verstandigung">
 					<input type="number" class="talent-taw" name="attr_ZfW_verstandigung" min="0" value="0">
 					<div class="talent-cell talent-taw">269</div>
@@ -11477,6 +15919,21 @@
 						<button type="roll" name="roll_z_verwandlungbeenden" value="@{z_verwandlungbeenden_action}"> <span>Verwandlung beenden</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_verwandlung_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_verwandlung">
 					<input type="number" class="talent-taw" name="attr_ZfW_verwandlung" min="0" value="0">
 					<div class="talent-cell talent-taw">270</div>
@@ -11491,6 +15948,21 @@
 						<button type="roll" name="roll_z_vipernblick" value="@{z_vipernblick_action}"> <span>Vipernblick</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_vipernblick_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_vipernblick">
 					<input type="number" class="talent-taw" name="attr_ZfW_vipernblick" min="0" value="0">
 					<div class="talent-cell talent-taw">271</div>
@@ -11505,6 +15977,21 @@
 						<button type="roll" name="roll_z_visibili" value="@{z_visibili_action}"> <span>Visibili Vanitar</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_visibili_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_visibili">
 					<input type="number" class="talent-taw" name="attr_ZfW_visibili" min="0" value="0">
 					<div class="talent-cell talent-taw">272</div>
@@ -11519,6 +16006,21 @@
 						<button type="roll" name="roll_z_vocolimbo" value="@{z_vocolimbo_action}"> <span>Vocolimbo Hohler Klang</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_vocolimbo_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_vocolimbo">
 					<input type="number" class="talent-taw" name="attr_ZfW_vocolimbo" min="0" value="0">
 					<div class="talent-cell talent-taw">273</div>
@@ -11533,6 +16035,21 @@
 						<button type="roll" name="roll_z_vogelzwitschern" value="@{z_vogelzwitschern_action}"> <span>Vogelzwitschern Glockenspiel</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_vogelzwitschern_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_vogelzwitschern">
 					<input type="number" class="talent-taw" name="attr_ZfW_vogelzwitschern" min="0" value="0">
 					<div class="talent-cell talent-taw">274</div>
@@ -11547,6 +16064,21 @@
 						<button type="roll" name="roll_z_wandausdornen" value="@{z_wandausdornen_action}"> <span>Wand aus Dornen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_wandausdornen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_wandausdornen">
 					<input type="number" class="talent-taw" name="attr_ZfW_wandausdornen" min="0" value="0">
 					<div class="talent-cell talent-taw">275</div>
@@ -11561,6 +16093,21 @@
 						<button type="roll" name="roll_z_wandausflammen" value="@{z_wandausflammen_action}"> <span>Wand aus Flammen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Wand_aus_Flammen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Wand_aus_Flammen">
 					<input type="number" class="talent-taw" name="attr_ZfW_Wand_aus_Flammen" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -11575,6 +16122,21 @@
 						<button type="roll" name="roll_z_warmesblut" value="@{z_warmesblut_action}"> <span>Warmes Blut</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_warmes_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_warmes">
 					<input type="number" class="talent-taw" name="attr_ZfW_warmes" min="0" value="0">
 					<div class="talent-cell talent-taw">276</div>
@@ -11589,6 +16151,21 @@
 						<button type="roll" name="roll_z_warmesgefriere" value="@{z_warmesgefriere_action}"> <span>Warmes gefriere</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Warmes_gefriere_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Warmes_gefriere">
 					<input type="number" class="talent-taw" name="attr_ZfW_Warmes_gefriere" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -11603,6 +16180,21 @@
 						<button type="roll" name="roll_z_wasseratem" value="@{z_wasseratem_action}"> <span>Wasseratem</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_wasseratem_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_wasseratem">
 					<input type="number" class="talent-taw" name="attr_ZfW_wasseratem" min="0" value="0">
 					<div class="talent-cell talent-taw">277</div>
@@ -11617,6 +16209,21 @@
 						<button type="roll" name="roll_z_wasserwall" value="@{z_wasserwall_action}"> <span>Wasserwall</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Wasserwall_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Wasserwall">
 					<input type="number" class="talent-taw" name="attr_ZfW_Wasserwall" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -11631,6 +16238,21 @@
 						<button type="roll" name="roll_z_weicheserstarre" value="@{z_weicheserstarre_action}"> <span>Weiches erstarre!</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_weiches_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_weiches">
 					<input type="number" class="talent-taw" name="attr_ZfW_weiches" min="0" value="0">
 					<div class="talent-cell talent-taw">278</div>
@@ -11645,6 +16267,21 @@
 						<button type="roll" name="roll_z_weihrauchwolke" value="@{z_weihrauchwolke_action}"> <span>Weihrauchwolke Wohlgeruch</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_weihrauchwolke_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_weihrauchwolke">
 					<input type="number" class="talent-taw" name="attr_ZfW_weihrauchwolke" min="0" value="0">
 					<div class="talent-cell talent-taw">279</div>
@@ -11659,6 +16296,21 @@
 						<button type="roll" name="roll_z_weisheitderbaeume" value="@{z_weisheitderbaeume_action}"> <span>Weisheit der Bäume</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="1 pro Woche Wirkungsdauer">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_weisheit_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_weisheit">
 					<input type="number" class="talent-taw" name="attr_ZfW_weisheit" min="0" value="0">
 					<div class="talent-cell talent-taw">280</div>
@@ -11673,6 +16325,21 @@
 						<button type="roll" name="roll_z_dz_weisheitdersteine" value="@{z_dz_weisheitdersteine_action}"> <span>Weisheit der Steine</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="1 pro Woche Wirkungsdauer">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_dz_Weisheit_der_Steine_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_dz_Weisheit_der_Steine">
 					<input type="number" class="talent-taw" name="attr_ZfW_Weisheit_der_Steine" min="0" value="0">
 					<div class="talent-cell talent-taw"><span class="abbr" title="Dunkle Zeiten">DZ</span></div>
@@ -11687,6 +16354,21 @@
 						<button type="roll" name="roll_z_weissemaehn" value="@{z_weissemaehn_action}"> <span>Weiße Mähn' und gold'ner Huf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_weisse_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_weisse">
 					<input type="number" class="talent-taw" name="attr_ZfW_weisse" min="0" value="0">
 					<div class="talent-cell talent-taw">281</div>
@@ -11701,6 +16383,21 @@
 						<button type="roll" name="roll_z_wellenlauf" value="@{z_wellenlauf_action}"> <span>Wellenlauf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/GE/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_wellenlauf_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_wellenlauf">
 					<input type="number" class="talent-taw" name="attr_ZfW_wellenlauf" min="0" value="0">
 					<div class="talent-cell talent-taw">282</div>
@@ -11715,6 +16412,21 @@
 						<button type="roll" name="roll_z_wettermeisterschaft" value="@{z_wettermeisterschaft_action}"> <span>Wettermeisterschaft</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/GE + <span class="abbr" title="Modifikator für die Stärke der Wetteränderung">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_wettermeisterschaft_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_wettermeisterschaft">
 					<input type="number" class="talent-taw" name="attr_ZfW_wettermeisterschaft" min="0" value="0">
 					<div class="talent-cell talent-taw">283</div>
@@ -11729,6 +16441,21 @@
 						<button type="roll" name="roll_z_widerwille" value="@{z_widerwille_action}"> <span>Widerwille Ungemach</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_widerwille_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_widerwille">
 					<input type="number" class="talent-taw" name="attr_ZfW_widerwille" min="0" value="0">
 					<div class="talent-cell talent-taw">285</div>
@@ -11743,6 +16470,21 @@
 						<button type="roll" name="roll_z_windbarriere" value="@{z_windbarriere_action}"> <span>Windbarriere</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Windbarriere_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Windbarriere">
 					<input type="number" class="talent-taw" name="attr_ZfW_Windbarriere" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -11757,6 +16499,21 @@
 						<button type="roll" name="roll_z_windgefluester" value="@{z_windgefluester_action}"> <span>Windgeflüster</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Windgefluester_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Windgefluester">
 					<input type="number" class="talent-taw" name="attr_ZfW_Windgefluester" min="0" value="0">
 					<div class="talent-cell talent-taw">-</div>
@@ -11771,6 +16528,21 @@
 						<button type="roll" name="roll_z_windhose" value="@{z_windhose_action}"> <span>Windhose</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Windhose_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Windhose">
 					<input type="number" class="talent-taw" name="attr_ZfW_Windhose" min="0" value="0">
 					<div class="talent-cell talent-taw">286</div>
@@ -11785,6 +16557,21 @@
 						<button type="roll" name="roll_z_windstille" value="@{z_windstille_action}"> <span>Windstille</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KK + <span class="abbr" title="Modifikator für die vorherrschende Windstärke">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Windstille_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Windstille">
 					<input type="number" class="talent-taw" name="attr_ZfW_Windstille" min="0" value="0">
 					<div class="talent-cell talent-taw">287</div>
@@ -11799,6 +16586,21 @@
 						<button type="roll" name="roll_z_wipfellauf" value="@{z_wipfellauf_action}"> <span>Wipfellauf</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Wipfellauf_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Wipfellauf">
 					<input type="number" class="talent-taw" name="attr_ZfW_Wipfellauf" min="0" value="0">
 					<div class="talent-cell talent-taw">288</div>
@@ -11813,6 +16615,21 @@
 						<button type="roll" name="roll_z_xenographus" value="@{z_xenographus_action}"> <span>Xenographus Schriftenkunde</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_xenographus_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_xenographus">
 					<input type="number" class="talent-taw" name="attr_ZfW_xenographus" min="0" value="0">
 					<div class="talent-cell talent-taw">289</div>
@@ -11827,6 +16644,21 @@
 						<button type="roll" name="roll_z_zagibu" value="@{z_zagibu_action}"> <span>Zagibu Ubigaz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zagibu_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zagibu">
 					<input type="number" class="talent-taw" name="attr_ZfW_zagibu" min="0" value="0">
 					<div class="talent-cell talent-taw">290</div>
@@ -11841,6 +16673,21 @@
 						<button type="roll" name="roll_z_zappenduster" value="@{z_zappenduster_action}"> <span>Zappenduster</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Zappenduster_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Zappenduster">
 					<input type="number" class="talent-taw" name="attr_ZfW_Zappenduster" min="0" value="0">
 					<div class="talent-cell talent-taw">291</div>
@@ -11855,6 +16702,21 @@
 						<button type="roll" name="roll_z_zauberklinge" value="@{z_zauberklinge_action}"> <span>Zauberklinge Geisterspeer</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zauberklinge_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zauberklinge">
 					<input type="number" class="talent-taw" name="attr_ZfW_zauberklinge" min="0" value="0">
 					<div class="talent-cell talent-taw">292</div>
@@ -11869,6 +16731,21 @@
 						<button type="roll" name="roll_z_zaubernahrung" value="@{z_zaubernahrung_action}"> <span>Zaubernahrung Hungerbann</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/KO + <span class="abbr" title="Modifikator für die Anzahl Tage ohne Nahrung und die Anzahl fehlender Lebenspunkte">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zaubernahrung_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zaubernahrung">
 					<input type="number" class="talent-taw" name="attr_ZfW_zaubernahrung" min="0" value="0">
 					<div class="talent-cell talent-taw">293</div>
@@ -11883,6 +16760,21 @@
 						<button type="roll" name="roll_z_zauberwesen" value="@{z_zauberwesen_action}"> <span>Zauberwesen der Natur</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zauberwesen_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zauberwesen">
 					<input type="number" class="talent-taw" name="attr_ZfW_zauberwesen" min="0" value="0">
 					<div class="talent-cell talent-taw">294</div>
@@ -11897,6 +16789,21 @@
 						<button type="roll" name="roll_z_zauberzwang" value="@{z_zauberzwang_action}"> <span>Zauberzwang</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zauberzwang_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zauberzwang">
 					<input type="number" class="talent-taw" name="attr_ZfW_zauberzwang" min="0" value="0">
 					<div class="talent-cell talent-taw">295</div>
@@ -11911,6 +16818,21 @@
 						<button type="roll" name="roll_z_zornderelemente" value="@{z_zornderelemente_action}"> <span>Zorn der Elemente</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Elementspezialisierung">Mod.</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zorn_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zorn">
 					<input type="number" class="talent-taw" name="attr_ZfW_zorn" min="0" value="0">
 					<div class="talent-cell talent-taw">296</div>
@@ -11925,6 +16847,21 @@
 						<button type="roll" name="roll_z_zungelaehmen" value="@{z_zungelaehmen_action}"> <span>Zunge lähmen</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_zunge_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_zunge">
 					<input type="number" class="talent-taw" name="attr_ZfW_zunge" min="0" value="0">
 					<div class="talent-cell talent-taw">297</div>
@@ -11939,6 +16876,21 @@
 						<button type="roll" name="roll_z_zwingtanz" value="@{z_zwingtanz_action}"> <span>Zwingtanz</span></button>
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
+					<div class="talent-cell talent-rep">
+						<select type="text" name="attr_z_Zwingtanz_rep">
+							<option value="">---</option>
+							<option value="Mag">Mag</option>
+							<option value="Elf">Elf</option>
+							<option value="Dru">Dru</option>
+							<option value="Sat">Hex</option>
+							<option value="Geo">Geo</option>
+							<option value="Sch">Sch</option>
+							<option value="Srl">Srl</option>
+							<option value="Bor">Bor</option>
+							<option value="Ach">Ach</option>
+							<option value="Kop">Kop</option>
+						</select>
+					</div>
 					<input type="text" class="talent-spez" name="attr_Spez_Zwingtanz">
 					<input type="number" class="talent-taw" name="attr_ZfW_Zwingtanz" min="0" value="0">
 					<div class="talent-cell talent-taw">298</div>
@@ -16425,6 +21377,11 @@
 			<td colspan="2" class="templates-warning"><span class="abbr" title="Der Wurf enthält zwei kritische Fehlschläge und wäre daher ohne den Vorteil Feste Matrix automatisch misslungen.">Feste Matrix hat Schlimmeres verhindert!</span></td>
 		</tr>
 		{{/rollBetween() computed::result -1 -1}}
+		{{#repmod}}
+		<tr>
+			<td colspan="2" class="templates-warning">Die verwendeten Attribute wurden durch die Repräsentation verändert.</td>
+		</tr>
+		{{/repmod}}
 	</table>
 </div>
 </rolltemplate>
@@ -22531,35 +27488,6 @@ function migrateTo20230618(migrationChain) {
 			});
 		});
 	});
-
-	/*
-	Migration steps: rename attribute subtag1 to z_repraesentation and map its value*/
-	function migrateTo20240421(migrationChain) {
-		var caller = "migrateTo20240314";
-		debugLog(caller, "Invoked.");
-		let valueMap = {
-			"---": "",
-			"gildenmagisch": "Mag",
-			"elfisch": "Elf",
-			"druidisch": "Dru",
-			"satuarisch": "Sat",
-			"geodisch": "Geo",
-			"schelmisch": "Sch",
-			"scharlatanisch": "Srl",
-			"borbaradianisch": "Bor",
-			"kristallomantisch": "Ach"
-		}
-		safeGetAttrs(["subtag1"], function (v) {
-			let attrsToChange = {
-				"z_repraesentation": valueMap[v[subtag1]]
-			}
-			safeSetAttrs(attrsToChange, {}, function () {
-				callNextMigration(migrationChain);
-			});
-		});
-		
-	}	
-
 }
 
 /*
@@ -22634,6 +27562,36 @@ function migrateTo20240414(migrationChain) {
 		});
 	});
 }
+}
+
+/*
+	Migration steps: rename attribute subtag1 to z_repraesentation and map its value
+*/
+function migrateTo20240421(migrationChain) {
+	var caller = "migrateTo20240421";
+	debugLog(caller, "Invoked.");
+	let valueMap = {
+		"---": "",
+		"gildenmagisch": "Mag",
+		"elfisch": "Elf",
+		"druidisch": "Dru",
+		"satuarisch": "Sat",
+		"geodisch": "Geo",
+		"schelmisch": "Sch",
+		"scharlatanisch": "Srl",
+		"borbaradianisch": "Bor",
+		"kristallomantisch": "Ach"
+	}
+	safeGetAttrs(["subtag1"], function (v) {
+		let attrsToChange = {
+			"z_erstrepraesentation": valueMap[v[subtag1]]
+		}
+		safeSetAttrs(attrsToChange, {}, function () {
+			callNextMigration(migrationChain);
+		});
+	});
+	
+}	
 /* migration end */
 /* base values begin */
 on(
@@ -23366,27 +28324,74 @@ on(talents_ebe.map(talent => "clicked:" + talent + "-ebe-action").join(" "), asy
 });
 /* talents end */
 /* magic begin */
-on(spells.map(spell => "clicked:" + spell + "-action").join(" "), async (info) => {
+function modifySpellAttributesByRepresentation(spellRepAttr, charData, spellAttrs) {
+	/* deal with representation special rules:
+		if representation is elven and KL > IN, replace first KL with IN 
+		if rep is achaz and two rolls are for KL or two are for IN, replace one of them with max(KL, IN)
+		if rep is kophtan, do something
+	*/
+	const func = "Attribute modification by spell representation";
+	let spellRep = (charData[spellRepAttr] === 0 || charData[spellRepAttr] === "")? charData["z_erstrepraesentation"] : charData[spellRepAttr];
+	debugLog(func, spellRep, charData, spellAttrs);
+	let modified = false;
+	switch (spellRep) {
+		case "Elf":
+			debugLog(func, "Adapting for elven rep");
+			if (charData['KL'] > charData['IN']) {
+				break;
+			}
+			for (let i = 0; i < 3; i++) {
+				if (spellAttrs[i] === "KL" && (spellAttrs[(i+1) % 3] !== "IN" || spellAttrs[(i + 2) % 3] !== "IN")) {
+					spellAttrs[i] = "IN";
+					modified = true;
+					break;
+				}
+			}
+			break;
+		case "Ach":
+			debugLog(func, "Adapting for achaz rep");
+			let doubleAttr = "";
+			if (spellAttrs[0] === "KL" || spellAttrs[0] === "IN") {
+				if	(spellAttrs[1] === spellAttrs[0] || spellAttrs[2] === spellAttrs[0]) {
+					doubleAttr = spellAttrs[0];
+				}
+			} else {
+				if ((spellAttrs[1] === "KL" || spellAttrs[1] === "IN") && spellAttrs[1] === spellAttrs[2]) {
+					doubleAttr = spellAttrs[1];
+				}
+			}
+			let otherAttr = doubleAttr === "KL" ? "IN" : "KL"
+			if (doubleAttr !== "" && charData[doubleAttr] < charData[otherAttr]) {
+				for (let i = 0; i < 3; i++) {
+					if (spellAttrs[i] === doubleAttr) {
+						spellAttrs[i] = otherAttr;
+						modified = true;
+						break;
+					}
+					
+				}
+			}
+			break;
+		case "Kop":
+			debugLog(func, "Adapting for kophtan rep");
+			//TODO
+			break;
+		default:
+			break;
+	}
+	return modified;
+}
+
+on(spells.map(spell => "clicked:" + spell + "-action").join(" "), (info) => {
 	var func = "Action Listener for Spell Roll Buttons";
 	var trigger = info["triggerName"].replace(/clicked:([^-]+)-action/, '$1');
 	var nameInternal = spellsData[trigger]["internal"];
 	var nameUI = spellsData[trigger]["ui"];
 	var stats = spellsData[trigger]["stats"];
+	var spellRepAttr = trigger + "_rep";
 	debugLog(func, trigger, spellsData[trigger]);
-	safeGetAttrs(["KL", "IN", "z_repraesentation", "v_festematrix", "n_spruchhemmung"], async function (v) {
-		/* deal with elven representation:
-			if representation is elven and KL > IN, replace first KL with IN 
-		*/
-		if (v["subtag1"] === "Elf" && v["KL"] < v["IN"]) {
-			if (stats[0] === "KL" && (stats[1] !== "IN" || stats[2] !== "IN")) {
-				stats[0] = "IN";
-			} else if (stats[1] === "KL") {
-				stats[1] = "IN";
-			} else if (stats[2] === "KL") {
-				stats[2] = "IN";
-			}
-		}
-		
+	safeGetAttrs(["z_erstrepraesentation", spellRepAttr, "v_festematrix", "n_spruchhemmung", "KL", "IN", "CH"], function (v) {
+		let repModified = modifySpellAttributesByRepresentation(spellRepAttr, v, stats);
 		// Build Roll Macro
 		var rollMacro = "";
 
@@ -23404,7 +28409,8 @@ on(spells.map(spell => "clicked:" + spell + "-action").join(" "), async (info) =
 			"{{roll=[[3d20cs<@{cs_zauber}cf>@{cf_zauber}]]}} " +
 			"{{result=[[0]]}} " +
 			"{{criticality=[[0]]}} " +
-			"{{critThresholds=[[[[@{cs_zauber}]]d1cs0cf2 + [[@{cf_zauber}]]d1cs0cf2]]}} ";
+			"{{critThresholds=[[[[@{cs_zauber}]]d1cs0cf2 + [[@{cf_zauber}]]d1cs0cf2]]}} " + 
+			"{{repmod=" + (repModified ? "Die verwendeten Attribute wurden durch die Repräsentation modifiziert" : "") + "}} ";
 		debugLog(func, rollMacro);
 
 		// Execute Roll
@@ -23456,31 +28462,37 @@ on(spells.map(spell => "clicked:" + spell + "-action").join(" "), async (info) =
 				let festeMatrix = v["v_festematrix"] === "0" ? false : true;
 				let spruchhemmung = v["n_spruchhemmung"] === "0" ? false : true;
 
-				for (roll of rolls) {
-					if (roll <= success) {
+				for (roll of rolls)
+				{
+					if (roll <= success)
+					{
 						successes += 1;
 					} else if (roll >= failure) {
 						failures += 1;
 					}
-					if (successes >= 2) {
+					if (successes >= 2)
+					{
 						criticality = successes;
 					} else if (failures >= 2) {
 						criticality = -failures;
 					}
 				}
 				// feste Matrix
-				if (festeMatrix && criticality === -2) {
+				if (festeMatrix && criticality === -2)
+				{
 					criticality = -1;
 					festeMatrixSave = true;
 
-					for (roll of rolls) {
+					for (roll of rolls)
+					{
 						if (
 							(roll > success) &&
 							(roll < failure) &&
 							(
 								roll === 18 || roll === 19
 							)
-						) {
+						)
+						{
 							criticality -= 1;
 							festeMatrixSave = false;
 						}
@@ -23509,19 +28521,23 @@ on(spells.map(spell => "clicked:" + spell + "-action").join(" "), async (info) =
 			var TaPstar = effTaW;
 
 			// Negativer TaW: |effTaW| zu Teilwürfen addieren
-			if (criticality >= 2) {
+			if (criticality >= 2)
+			{
 				TaPstar = TaW;
 				result = 1;
 			} else {
-				if (effTaW < 0) {
-					for (roll in rolls) {
+				if (effTaW < 0)
+				{
+					for (roll in rolls)
+					{
 						effRolls[roll] = rolls[roll] + Math.abs(effTaW);
 					}
 					TaPstar = 0;
 				}
 
 				// TaP-Verbrauch für jeden Wurf
-				for (roll in effRolls) {
+				for (roll in effRolls)
+				{
 					TaPstar -= Math.max(0, effRolls[roll] - stats[roll]);
 				}
 
@@ -23529,11 +28545,14 @@ on(spells.map(spell => "clicked:" + spell + "-action").join(" "), async (info) =
 				TaPstar = Math.min(TaW, TaPstar);
 
 				// Ergebnis an Doppel/Dreifach-20 anpassen
-				if (Math.abs(criticality) <= 1) {
+				if (Math.abs(criticality) <= 1)
+				{
 					result = TaPstar < 0 ? 0 : 1;
-					if (festeMatrixSave && result === 0) {
+					if (festeMatrixSave && result === 0)
+					{
 						result = -1;
-					} else if (festeMatrixSave && result === 1) {
+					} else if (festeMatrixSave && result === 1)
+					{
 						result = 2;
 					}
 				} else if (criticality <= -2) {

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -7280,17 +7280,17 @@
 		<br>
 		<div class="section section-Zauberbogen" align="center">
 			<b>Repräsentation</b>
-			<select type="text" name="attr_subtag1" style="width: 12em;">
-				<option>---</option>
-				<option>gildenmagisch</option>
-				<option>elfisch</option>
-				<option>druidisch</option>
-				<option>satuarisch</option>
-				<option>geodisch</option>
-				<option>schelmisch</option>
-				<option>scharlatanisch</option>
-				<option>borbaradianisch</option>
-				<option>kristallomantisch</option>
+			<select type="text" name="attr_z_repraesentation" style="width: 12em;">
+				<option value="">---</option>
+				<option value="Mag">gildenmagisch</option>
+				<option value="Elf">elfisch</option>
+				<option value="Dru">druidisch</option>
+				<option value="Sat">satuarisch</option>
+				<option value="Geo">geodisch</option>
+				<option value="Sch">schelmisch</option>
+				<option value="Srl">scharlatanisch</option>
+				<option value="Bor">borbaradianisch</option>
+				<option value="Ach">kristallomantisch</option>
 			</select>
 			<br>
 			<b>Merkmale</b>
@@ -21715,6 +21715,7 @@ var versionsWithMigrations = [
 		20220821,
 		20230618,
 		20240414
+		20240421
 ];
 
 /*
@@ -22530,6 +22531,35 @@ function migrateTo20230618(migrationChain) {
 			});
 		});
 	});
+
+	/*
+	Migration steps: rename attribute subtag1 to z_repraesentation and map its value*/
+	function migrateTo20240421(migrationChain) {
+		var caller = "migrateTo20240314";
+		debugLog(caller, "Invoked.");
+		let valueMap = {
+			"---": "",
+			"gildenmagisch": "Mag",
+			"elfisch": "Elf",
+			"druidisch": "Dru",
+			"satuarisch": "Sat",
+			"geodisch": "Geo",
+			"schelmisch": "Sch",
+			"scharlatanisch": "Srl",
+			"borbaradianisch": "Bor",
+			"kristallomantisch": "Ach"
+		}
+		safeGetAttrs(["subtag1"], function (v) {
+			let attrsToChange = {
+				"z_repraesentation": valueMap[v[subtag1]]
+			}
+			safeSetAttrs(attrsToChange, {}, function () {
+				callNextMigration(migrationChain);
+			});
+		});
+		
+	}	
+
 }
 
 /*
@@ -23343,184 +23373,184 @@ on(spells.map(spell => "clicked:" + spell + "-action").join(" "), async (info) =
 	var nameUI = spellsData[trigger]["ui"];
 	var stats = spellsData[trigger]["stats"];
 	debugLog(func, trigger, spellsData[trigger]);
-
-	// Build Roll Macro
-	var rollMacro = "";
-
-	rollMacro +=
-		"@{gm_roll_opt} " +
-		"&{template:zauber} " +
-		"{{name=" + nameUI + "}} " +
-		"{{wert=[[@{ZfW_" + nameInternal + "}d1cs0cf2]]}} " +
-		"{{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} " +
-		"{{stats=[[ " +
-			"[Eigenschaft 1:] [[@{" + stats[0] + "}]]d1cs0cf2 + " +
-			"[Eigenschaft 2:] [[@{" + stats[1] + "}]]d1cs0cf2 + " +
-			"[Eigenschaft 3:] [[@{" + stats[2] + "}]]d1cs0cf2" +
-			"]]}} " +
-		"{{roll=[[3d20cs<@{cs_zauber}cf>@{cf_zauber}]]}} " +
-		"{{result=[[0]]}} " +
-		"{{criticality=[[0]]}} " +
-		"{{critThresholds=[[[[@{cs_zauber}]]d1cs0cf2 + [[@{cf_zauber}]]d1cs0cf2]]}} ";
-	debugLog(func, rollMacro);
-
-	// Execute Roll
-	results = await startRoll(rollMacro);
-	console.log("test: info:", info, "results:", results);
-	var rollID = results.rollId;
-	results = results.results;
-	var TaW = results.wert.result;
-	var mod = results.mod.result;
-	var stats = [
-		results.stats.rolls[0].dice,
-		results.stats.rolls[1].dice,
-		results.stats.rolls[2].dice
-	];
-	var rolls = results.roll.rolls[0].results;
-	var success = results.critThresholds.rolls[0].dice;
-	var failure = results.critThresholds.rolls[1].dice;
-	/* Result
-	-1	Failure (due to Firm Matrix)
-	 0	Failure
-	 1	Success
-	 2	Success (due to Firm Matrix)
-	*/
-	var result = 0;
-	/* Criticality
-	-4	Two or more dice same result (not 1, not 20); via Spell Stalling (Spruchhemmung)
-	-3	Triple 20
-	-2	Double 20
-	 0	no double 1/20
-	+2	Double 1
-	+3	Triple 1
-	*/
-	var criticality = 0;
-
-	safeGetAttrs(["v_festematrix", "n_spruchhemmung"], function(v) {
-		/*
-			Doppel/Dreifach-1/20-Berechnung
-			Vor der TaP*-Berechnung, da diese damit gegebenenfalls hinfällig wird
+	safeGetAttrs(["KL", "IN", "z_repraesentation", "v_festematrix", "n_spruchhemmung"], async function (v) {
+		/* deal with elven representation:
+			if representation is elven and KL > IN, replace first KL with IN 
 		*/
-		/*
-		Variable, um festhalten zu können, dass ein
-			* normal misslungenes Ergebnis ohne Feste Matrix automatisch misslungen wäre und
-			* normal gelungenes Ergebnis ohne Feste Matrix automatisch misslungen wäre
-		*/
-		var festeMatrixSave = false;
-		{
-			let successes = 0;
-			let failures = 0;
-			let festeMatrix = v["v_festematrix"] === "0" ? false : true;
-			let spruchhemmung = v["n_spruchhemmung"] === "0" ? false : true;
-
-			for (roll of rolls)
-			{
-				if (roll <= success)
-				{
-					successes += 1;
-				} else if (roll >= failure) {
-					failures += 1;
-				}
-				if (successes >= 2)
-				{
-					criticality = successes;
-				} else if (failures >= 2) {
-					criticality = -failures;
-				}
+		if (v["subtag1"] === "Elf" && v["KL"] < v["IN"]) {
+			if (stats[0] === "KL" && (stats[1] !== "IN" || stats[2] !== "IN")) {
+				stats[0] = "IN";
+			} else if (stats[1] === "KL") {
+				stats[1] = "IN";
+			} else if (stats[2] === "KL") {
+				stats[2] = "IN";
 			}
-			// feste Matrix
-			if (festeMatrix && criticality === -2)
-			{
-				criticality = -1;
-				festeMatrixSave = true;
+		}
+		
+		// Build Roll Macro
+		var rollMacro = "";
 
-				for (roll of rolls)
-				{
-					if (
-						(roll > success) &&
-						(roll < failure) &&
-						(
-							roll === 18 || roll === 19
-						)
-					)
-					{
-						criticality -= 1;
-						festeMatrixSave = false;
+		rollMacro +=
+			"@{gm_roll_opt} " +
+			"&{template:zauber} " +
+			"{{name=" + nameUI + "}} " +
+			"{{wert=[[@{ZfW_" + nameInternal + "}d1cs0cf2]]}} " +
+			"{{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} " +
+			"{{stats=[[ " +
+				"[Eigenschaft 1:] [[@{" + stats[0] + "}]]d1cs0cf2 + " +
+				"[Eigenschaft 2:] [[@{" + stats[1] + "}]]d1cs0cf2 + " +
+				"[Eigenschaft 3:] [[@{" + stats[2] + "}]]d1cs0cf2" +
+				"]]}} " +
+			"{{roll=[[3d20cs<@{cs_zauber}cf>@{cf_zauber}]]}} " +
+			"{{result=[[0]]}} " +
+			"{{criticality=[[0]]}} " +
+			"{{critThresholds=[[[[@{cs_zauber}]]d1cs0cf2 + [[@{cf_zauber}]]d1cs0cf2]]}} ";
+		debugLog(func, rollMacro);
+
+		// Execute Roll
+		startRoll(rollMacro).then((results) => {
+			console.log("test: info:", info, "results:", results);
+			var rollID = results.rollId;
+			results = results.results;
+			var TaW = results.wert.result;
+			var mod = results.mod.result;
+			var stats = [
+				results.stats.rolls[0].dice,
+				results.stats.rolls[1].dice,
+				results.stats.rolls[2].dice
+			];
+			var rolls = results.roll.rolls[0].results;
+			var success = results.critThresholds.rolls[0].dice;
+			var failure = results.critThresholds.rolls[1].dice;
+			/* Result
+			-1	Failure (due to Firm Matrix)
+			0	Failure
+			1	Success
+			2	Success (due to Firm Matrix)
+			*/
+			var result = 0;
+			/* Criticality
+			-4	Two or more dice same result (not 1, not 20); via Spell Stalling (Spruchhemmung)
+			-3	Triple 20
+			-2	Double 20
+			0	no double 1/20
+			+2	Double 1
+			+3	Triple 1
+			*/
+			var criticality = 0;
+
+
+			/*
+				Doppel/Dreifach-1/20-Berechnung
+				Vor der TaP*-Berechnung, da diese damit gegebenenfalls hinfällig wird
+			*/
+			/*
+			Variable, um festhalten zu können, dass ein
+				* normal misslungenes Ergebnis ohne Feste Matrix automatisch misslungen wäre und
+				* normal gelungenes Ergebnis ohne Feste Matrix automatisch misslungen wäre
+			*/
+			var festeMatrixSave = false;
+			{
+				let successes = 0;
+				let failures = 0;
+				let festeMatrix = v["v_festematrix"] === "0" ? false : true;
+				let spruchhemmung = v["n_spruchhemmung"] === "0" ? false : true;
+
+				for (roll of rolls) {
+					if (roll <= success) {
+						successes += 1;
+					} else if (roll >= failure) {
+						failures += 1;
+					}
+					if (successes >= 2) {
+						criticality = successes;
+					} else if (failures >= 2) {
+						criticality = -failures;
 					}
 				}
-			}
-			// Spruchhemmung, soll nur auslösen, wenn eh nicht Doppel/Dreifach-1/20
-			if (
-				spruchhemmung &&
-				criticality > -2 &&
-				criticality < 2 &&
-				(
-					(rolls[0] === rolls[1]) ||
-					(rolls[1] === rolls[2]) ||
-					(rolls[2] === rolls[0])
-				)
-			)
-			{
-				criticality = -4;
-			}
-		}
+				// feste Matrix
+				if (festeMatrix && criticality === -2) {
+					criticality = -1;
+					festeMatrixSave = true;
 
-		/*
-			TaP*-Berechnung
-		*/
-		var effRolls = rolls;
-		var effTaW = TaW - mod;
-		var TaPstar = effTaW;
-
-		// Negativer TaW: |effTaW| zu Teilwürfen addieren
-		if (criticality >= 2)
-		{
-			TaPstar = TaW;
-			result = 1;
-		} else {
-			if (effTaW < 0)
-			{
-				for (roll in rolls)
-				{
-					effRolls[roll] = rolls[roll] + Math.abs(effTaW);
+					for (roll of rolls) {
+						if (
+							(roll > success) &&
+							(roll < failure) &&
+							(
+								roll === 18 || roll === 19
+							)
+						) {
+							criticality -= 1;
+							festeMatrixSave = false;
+						}
+					}
 				}
-				TaPstar = 0;
-			}
-
-			// TaP-Verbrauch für jeden Wurf
-			for (roll in effRolls)
-			{
-				TaPstar -= Math.max(0, effRolls[roll] - stats[roll]);
-			}
-
-			// Max. TaP* = TaW, mindestens aber 0
-			TaPstar = Math.min(Math.max(TaW, 0), TaPstar);
-
-			// Ergebnis an Doppel/Dreifach-20 anpassen
-			if (Math.abs(criticality) <= 1)
-			{
-				result = TaPstar < 0 ? 0 : 1;
-				if (festeMatrixSave && result === 0)
-				{
-					result = -1;
-				} else if (festeMatrixSave && result === 1)
-				{
-					result = 2;
+				// Spruchhemmung, soll nur auslösen, wenn eh nicht Doppel/Dreifach-1/20
+				if (
+					spruchhemmung &&
+					criticality > -2 &&
+					criticality < 2 &&
+					(
+						(rolls[0] === rolls[1]) ||
+						(rolls[1] === rolls[2]) ||
+						(rolls[2] === rolls[0])
+					)
+				) {
+					criticality = -4;
 				}
-			} else if (criticality <= -2) {
-				result = 0;
 			}
-		}
 
-		finishRoll(
-			rollID,
-			{
-				roll: TaPstar,
-				result: result,
-				criticality: criticality,
-				stats: stats.toString().replaceAll(",", "/")
+			/*
+				TaP*-Berechnung
+			*/
+			var effRolls = rolls;
+			var effTaW = TaW - mod;
+			var TaPstar = effTaW;
+
+			// Negativer TaW: |effTaW| zu Teilwürfen addieren
+			if (criticality >= 2) {
+				TaPstar = TaW;
+				result = 1;
+			} else {
+				if (effTaW < 0) {
+					for (roll in rolls) {
+						effRolls[roll] = rolls[roll] + Math.abs(effTaW);
+					}
+					TaPstar = 0;
+				}
+
+				// TaP-Verbrauch für jeden Wurf
+				for (roll in effRolls) {
+					TaPstar -= Math.max(0, effRolls[roll] - stats[roll]);
+				}
+
+				// Max. TaP* = TaW
+				TaPstar = Math.min(TaW, TaPstar);
+
+				// Ergebnis an Doppel/Dreifach-20 anpassen
+				if (Math.abs(criticality) <= 1) {
+					result = TaPstar < 0 ? 0 : 1;
+					if (festeMatrixSave && result === 0) {
+						result = -1;
+					} else if (festeMatrixSave && result === 1) {
+						result = 2;
+					}
+				} else if (criticality <= -2) {
+					result = 0;
+				}
 			}
-		);
+
+			finishRoll(
+				rollID,
+				{
+					roll: TaPstar,
+					result: result,
+					criticality: criticality,
+					stats: stats.toString().replaceAll(",", "/")
+				}
+			);
+		});
 	});
 });
 /* magic end */

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -7383,7 +7383,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Adamantium_rep">
+						<select type="text" name="attr_z_adamantium_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7412,7 +7412,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Adlerauge_rep">
+						<select type="text" name="attr_z_adlerauge_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7441,7 +7441,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Adlerschwinge_rep">
+						<select type="text" name="attr_z_adlerschwinge_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7470,7 +7470,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aeolitus_rep">
+						<select type="text" name="attr_z_aeolitus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7499,7 +7499,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aerofugo_rep">
+						<select type="text" name="attr_z_aerofugo_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7528,7 +7528,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aerogelo_rep">
+						<select type="text" name="attr_z_aerogelo_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7557,7 +7557,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aeropulvis_rep">
+						<select type="text" name="attr_z_aeropulvis_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7615,7 +7615,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/GE + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Alpgestalt_rep">
+						<select type="text" name="attr_z_alpgestalt_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7644,7 +7644,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN + <span class="abbr" title="Modifikator für die Analyseschwierigkeit">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Analys_rep">
+						<select type="text" name="attr_z_analys_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7673,7 +7673,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_angste_rep">
+						<select type="text" name="attr_z_aengstelindern_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7702,7 +7702,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Animatio_rep">
+						<select type="text" name="attr_z_animatio_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7731,7 +7731,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Applicatus_rep">
+						<select type="text" name="attr_z_applicatus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7760,7 +7760,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aquafaxius_rep">
+						<select type="text" name="attr_z_aquafaxius_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7789,7 +7789,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aquaqueris_rep">
+						<select type="text" name="attr_z_aquaqueris_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7818,7 +7818,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aquasphaero_rep">
+						<select type="text" name="attr_z_aquasphaero_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7847,7 +7847,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Arachnea_rep">
+						<select type="text" name="attr_z_arachnea_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7876,7 +7876,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Arcanovi_rep">
+						<select type="text" name="attr_z_arcanovi_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7905,7 +7905,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Archofaxius_rep">
+						<select type="text" name="attr_z_archofaxius_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7934,7 +7934,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Archosphaero_rep">
+						<select type="text" name="attr_z_archosphaero_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7963,7 +7963,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Armatrutz_rep">
+						<select type="text" name="attr_z_armatrutz_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -7992,7 +7992,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Atemnot_rep">
+						<select type="text" name="attr_z_atemnot_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8061,7 +8061,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/KO/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aufgeblasen_rep">
+						<select type="text" name="attr_z_aufgeblasen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8090,7 +8090,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Auge_rep">
+						<select type="text" name="attr_z_augedeslimbus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8119,7 +8119,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Aureolus_rep">
+						<select type="text" name="attr_z_aureolus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8148,7 +8148,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Auris_rep">
+						<select type="text" name="attr_z_aurisnasusoculus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8177,7 +8177,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/GE/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Axxeleratus_rep">
+						<select type="text" name="attr_z_axxeleratus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8206,7 +8206,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Heilung regeltechnischer Wunden">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Balsam_rep">
+						<select type="text" name="attr_z_balsam_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8235,7 +8235,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_band_rep">
+						<select type="text" name="attr_z_bandundfessel_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8264,7 +8264,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Bannbaladin_rep">
+						<select type="text" name="attr_z_bannbaladin_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8293,7 +8293,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KO/KK + <span class="abbr" title="Modifikator für die Dauer des Schlafs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Barenruhe_rep">
+						<select type="text" name="attr_z_baerenruhe_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8322,7 +8322,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Beherrschung_rep">
+						<select type="text" name="attr_z_beherrschungbrechen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8380,7 +8380,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs und der beschworenen Wesenheit">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Beschworung_rep">
+						<select type="text" name="attr_z_beschwoerungvereiteln_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8409,7 +8409,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Bewegung_rep">
+						<select type="text" name="attr_z_bewegungstoeren_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8467,7 +8467,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Blendwerk_rep">
+						<select type="text" name="attr_z_blendwerk_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8612,7 +8612,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/GE + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Blitz_rep">
+						<select type="text" name="attr_z_blitz_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8641,7 +8641,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_boser_rep">
+						<select type="text" name="attr_z_boeserblick_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -8989,7 +8989,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_damonenbann_rep">
+						<select type="text" name="attr_z_daemonenbann_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9105,7 +9105,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_dichter_rep">
+						<select type="text" name="attr_z_dichterunddenker_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9134,7 +9134,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Dschinnenruf_rep">
+						<select type="text" name="attr_z_dschinnenruf_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9163,7 +9163,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Dunkelheit_rep">
+						<select type="text" name="attr_z_dunkelheit_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9250,7 +9250,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_eigenschaft_rep">
+						<select type="text" name="attr_z_eigenschaftwiederherstellen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9279,7 +9279,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_eigne_rep">
+						<select type="text" name="attr_z_eigneaengste_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9308,7 +9308,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_einfluss_rep">
+						<select type="text" name="attr_z_einflussbannen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9337,7 +9337,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_eins_rep">
+						<select type="text" name="attr_z_einsmitdernatur_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9395,7 +9395,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_eiseskalte_rep">
+						<select type="text" name="attr_z_eiseskaelte_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9424,7 +9424,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Eiswirbel_rep">
+						<select type="text" name="attr_z_eiswirbel_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9453,7 +9453,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Elementarbann_rep">
+						<select type="text" name="attr_z_elementarbann_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9482,7 +9482,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_elementarer_rep">
+						<select type="text" name="attr_z_elementarerdiener_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9569,7 +9569,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_erinnerung_rep">
+						<select type="text" name="attr_z_erinnerungverlassedich_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9685,7 +9685,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Fesselranken_rep">
+						<select type="text" name="attr_z_fesselranken_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9714,7 +9714,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Feuermaehne_rep">
+						<select type="text" name="attr_z_feuermaehne_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9743,7 +9743,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Feuersturm_rep">
+						<select type="text" name="attr_z_feuersturm_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9772,7 +9772,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Firnlauf_rep">
+						<select type="text" name="attr_z_firnlauf_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9801,7 +9801,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_flim_rep">
+						<select type="text" name="attr_z_flimflam_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9830,7 +9830,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_fluch_rep">
+						<select type="text" name="attr_z_fluchderpestilenz_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9917,7 +9917,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Frigifaxius_rep">
+						<select type="text" name="attr_z_frigifaxius_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -9946,7 +9946,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Frigisphaero_rep">
+						<select type="text" name="attr_z_frigisphaero_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10091,7 +10091,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_gefass_rep">
+						<select type="text" name="attr_z_gefaessderjahre_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10149,7 +10149,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Austreibungsschwierigkeit des Geistes">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Geisterbann_rep">
+						<select type="text" name="attr_z_geisterbann_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10178,7 +10178,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Geistes">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Geisterruf_rep">
+						<select type="text" name="attr_z_geisterruf_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10236,7 +10236,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Glacoflumen_rep">
+						<select type="text" name="attr_z_glacoflumen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10265,7 +10265,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Gletscherwand_rep">
+						<select type="text" name="attr_z_gletscherwand_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10294,7 +10294,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_granit_rep">
+						<select type="text" name="attr_z_granitundmarmor_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10410,7 +10410,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Halluzination_rep">
+						<select type="text" name="attr_z_halluzination_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10439,7 +10439,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Harmlose_rep">
+						<select type="text" name="attr_z_harmlosegestalt_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10468,7 +10468,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_hartes_rep">
+						<select type="text" name="attr_z_hartesschmelze_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10555,7 +10555,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_heilkraft_rep">
+						<select type="text" name="attr_z_heilkraftbannen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10584,7 +10584,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_hellsicht_rep">
+						<select type="text" name="attr_z_hellsichttrueben_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10613,7 +10613,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_herbeirufung_rep">
+						<select type="text" name="attr_z_herbeirufungvereiteln_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10642,7 +10642,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_herr_rep">
+						<select type="text" name="attr_z_herrueberdastierreich_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10671,7 +10671,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_herzschlag_rep">
+						<select type="text" name="attr_z_herzschlagruhe_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10729,7 +10729,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Hexenblick_rep">
+						<select type="text" name="attr_z_hexenblick_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10758,7 +10758,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Hexengalle_rep">
+						<select type="text" name="attr_z_hexengalle_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10787,7 +10787,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Hexenholz_rep">
+						<select type="text" name="attr_z_hexenholz_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10816,7 +10816,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Hexenknoten_rep">
+						<select type="text" name="attr_z_hexenknoten_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10845,7 +10845,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Hexenkrallen_rep">
+						<select type="text" name="attr_z_hexenkrallen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10874,7 +10874,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Hexenspeichel_rep">
+						<select type="text" name="attr_z_hexenspeichel_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10903,7 +10903,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="geistige Magieresistenz des Tieres">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_hilfreiche_rep">
+						<select type="text" name="attr_z_hilfreichetatze_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10932,7 +10932,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_hollenpein_rep">
+						<select type="text" name="attr_z_hoellenpein_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -10961,7 +10961,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Holterdipolter_rep">
+						<select type="text" name="attr_z_holterdipolter_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11048,7 +11048,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Humofaxius_rep">
+						<select type="text" name="attr_z_humofaxius_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11077,7 +11077,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Humosphaero_rep">
+						<select type="text" name="attr_z_humosphaero_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11164,7 +11164,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Ignifugo_rep">
+						<select type="text" name="attr_z_ignifugo_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11193,7 +11193,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Ignimorpho_rep">
+						<select type="text" name="attr_z_ignimorpho_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11222,7 +11222,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Igniplano_rep">
+						<select type="text" name="attr_z_igniplano_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11338,7 +11338,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_illusion_rep">
+						<select type="text" name="attr_z_illusionaufloesen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11570,7 +11570,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/IN + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_iribaars_rep">
+						<select type="text" name="attr_z_iribaarshand_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11657,7 +11657,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Katzenaugen_rep">
+						<select type="text" name="attr_z_katzenaugen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11686,7 +11686,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/CH + <span class="abbr" title="Modifikator für die Giftstufe">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_klarum_rep">
+						<select type="text" name="attr_z_klarumpurum_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11715,7 +11715,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Klickeradomms_rep">
+						<select type="text" name="attr_z_klickeradomms_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11744,7 +11744,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Koboldgeschenk_rep">
+						<select type="text" name="attr_z_koboldgeschenk_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11773,7 +11773,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Koboldovision_rep">
+						<select type="text" name="attr_z_koboldovision_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11802,7 +11802,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_komm_rep">
+						<select type="text" name="attr_z_kommkoboldkomm_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11831,7 +11831,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/IN</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_koerperlose_rep">
+						<select type="text" name="attr_z_koerperlosereise_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11860,7 +11860,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_krabbelnder_rep">
+						<select type="text" name="attr_z_krabbelnderschrecken_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11889,7 +11889,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KO/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_kraft_rep">
+						<select type="text" name="attr_z_kraftdeserzes_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11918,7 +11918,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_kraft_humus_rep">
+						<select type="text" name="attr_z_kraftdeshumus_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11947,7 +11947,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_krahenruf_rep">
+						<select type="text" name="attr_z_kraehenruf_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -11976,7 +11976,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/GE/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_krotensprung_rep">
+						<select type="text" name="attr_z_kroetensprung_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12063,7 +12063,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_lach_rep">
+						<select type="text" name="attr_z_lachdichgesund_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12092,7 +12092,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Lachkrampf_rep">
+						<select type="text" name="attr_z_lachkrampf_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12121,7 +12121,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">CH/GE/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_langer_rep">
+						<select type="text" name="attr_z_langerlulatsch_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12150,7 +12150,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_last_rep">
+						<select type="text" name="attr_z_lastdesalters_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12382,7 +12382,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Leidensbund_rep">
+						<select type="text" name="attr_z_leidensbund_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12411,7 +12411,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_levthans_rep">
+						<select type="text" name="attr_z_levthansfeuer_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12440,7 +12440,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_limbus_rep">
+						<select type="text" name="attr_z_limbusversiegeln_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12498,7 +12498,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_lunge_rep">
+						<select type="text" name="attr_z_lungedesleviatan_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12527,7 +12527,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/IN</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_madas_rep">
+						<select type="text" name="attr_z_madasspiegel_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12556,7 +12556,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KO + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_magischer_rep">
+						<select type="text" name="attr_z_magischerraub_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12585,7 +12585,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Mahlstrom_rep">
+						<select type="text" name="attr_z_mahlstrom_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12614,7 +12614,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Malmkreis_rep">
+						<select type="text" name="attr_z_malmkreis_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12817,7 +12817,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_metamagie_rep">
+						<select type="text" name="attr_z_metamagieneutralisieren_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12846,7 +12846,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_metamorpho_felsenform_rep">
+						<select type="text" name="attr_z_metamorphofelsenform_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12875,7 +12875,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_metamorpho_rep">
+						<select type="text" name="attr_z_metamorphogletscherform_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12962,7 +12962,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF + <span class="abbr" title="höchste Magieresistenz plus Anzahl Betroffener">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_murks_rep">
+						<select type="text" name="attr_z_murksundpatz_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -12991,7 +12991,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Gesamtrüstschutz des Opfers">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Nackedei_rep">
+						<select type="text" name="attr_z_nackedei_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -13020,7 +13020,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Nebelleib_rep">
+						<select type="text" name="attr_z_nebelleib_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -13165,7 +13165,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_objecto_rep">
+						<select type="text" name="attr_z_objectoobscuro_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -13194,7 +13194,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Objectofixo_rep">
+						<select type="text" name="attr_z_objectofixo_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -13252,7 +13252,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_objekt_rep">
+						<select type="text" name="attr_z_objektentzaubern_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -13339,7 +13339,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Orcanofaxius_rep">
+						<select type="text" name="attr_z_orcanofaxius_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -13368,7 +13368,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Orcanosphaero_rep">
+						<select type="text" name="attr_z_orcanosphaero_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -13397,7 +13397,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/MU/CH + <span class="abbr" title="Modifikator für die Größe des dämonenverseuchten Gebiets">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Pandaemonium_rep">
+						<select type="text" name="attr_z_pandaemonium_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -13455,7 +13455,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Papperlapapp_rep">
+						<select type="text" name="attr_z_papperlapapp_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -13484,7 +13484,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/KK + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_paralys_rep">
+						<select type="text" name="attr_z_paralysis_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -13600,7 +13600,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Modifikator für die Entdeckungsschwierigkeit der Krankheit oder der Giftstufe des Giftes">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_pestilenz_rep">
+						<select type="text" name="attr_z_pestilenzerspueren_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -14093,7 +14093,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KO</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_ruhe_rep">
+						<select type="text" name="attr_z_ruhekoerper_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -14151,7 +14151,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Sanftmut_rep">
+						<select type="text" name="attr_z_sanftmut_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -14209,7 +14209,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_satuarias_rep">
+						<select type="text" name="attr_z_satuariasherrlichkeit_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -14238,7 +14238,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Schabernack_rep">
+						<select type="text" name="attr_z_schabernack_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -14267,7 +14267,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_schadenszauber_rep">
+						<select type="text" name="attr_z_schadenszauberbannen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -14296,7 +14296,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Schelmenkleister_rep">
+						<select type="text" name="attr_z_schelmenkleister_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -14325,7 +14325,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Höchste Magieresistenz + Zahl der Betroffenen + Stärke des Stimmungsumschwungs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Schelmenlaune_rep">
+						<select type="text" name="attr_z_schelmenlaune_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -14354,7 +14354,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Schelmenmaske_rep">
+						<select type="text" name="attr_z_schelmenmaske_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -14383,7 +14383,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Schelmenrausch_rep">
+						<select type="text" name="attr_z_schelmenrausch_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -14441,7 +14441,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_schleier_rep">
+						<select type="text" name="attr_z_schleierderunwissenheit_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -14557,7 +14557,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_seelentier_rep">
+						<select type="text" name="attr_z_seelentiererkennen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15079,7 +15079,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Modifikator für die handwerkliche Qualität des unbelebten Golemids, das Grundmaterial, die elementare Reinheit des Ausgangsmaterials, der Größe des Golemids, der Eigenschaften des Golemids, die Anzahl weiterer Dienste, die besonderen Fähigkeiten des Golemids und die Talentwerte des Golemids">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_staub_rep">
+						<select type="text" name="attr_z_staubwandle_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15108,7 +15108,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Steinmauer_rep">
+						<select type="text" name="attr_z_steinmauer_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15137,7 +15137,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KK + <span class="abbr" title="Modifikator für die handwerkliche Qualität des unbelebten Golems, das Grundmaterial, die Affinität des Materials zum Erzdämonen, der Größe des Golems, der Eigenschaften des Golems, die Anzahl weiterer Dienste, die besonderen Fähigkeiten des Golems und die Talentwerte des Golems">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_stein_rep">
+						<select type="text" name="attr_z_steinwandle_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15195,7 +15195,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/IN</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Stimmen_des_Windes_rep">
+						<select type="text" name="attr_z_stimmendeswindes_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15224,7 +15224,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Sumpfstrudel_rep">
+						<select type="text" name="attr_z_sumpfstrudel_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15253,7 +15253,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_sumus_rep">
+						<select type="text" name="attr_z_sumuselixiere_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15340,7 +15340,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK + <span class="abbr" title="1 pro Kampfrunde">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_tempus_rep">
+						<select type="text" name="attr_z_tempusstasis_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15398,7 +15398,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/CH + <span class="abbr" title="Modifikator für die Anzahl zu heilender regeltechnischer Wunden, der Stufe der Krankheit oder der halben Giftstufe">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_tiere_rep">
+						<select type="text" name="attr_z_tierebesprechen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15485,7 +15485,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_tlalucs_rep">
+						<select type="text" name="attr_z_tlalucsodem_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15514,7 +15514,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Anrufungsschwierigkeit des Untoten">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_totes_rep">
+						<select type="text" name="attr_z_toteshandle_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15630,7 +15630,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/CH/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Traumgestalt_rep">
+						<select type="text" name="attr_z_traumgestalt_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15659,7 +15659,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Umbraporta_rep">
+						<select type="text" name="attr_z_umbraporta_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15688,7 +15688,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/FF/KO + <span class="abbr" title="1 pro Tag Wirkungsdauer über den ersten hinaus">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_unberuhrt_rep">
+						<select type="text" name="attr_z_unberuehrt_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15775,7 +15775,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/FF/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_unsichtbarer_rep">
+						<select type="text" name="attr_z_unsichtbarerjaeger_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15833,7 +15833,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/KO + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_veranderung_rep">
+						<select type="text" name="attr_z_veraenderungaufheben_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15891,7 +15891,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/KL/IN + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_verstandigung_rep">
+						<select type="text" name="attr_z_verstaendigungstoeren_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -15920,7 +15920,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/FF + <span class="abbr" title="Modifikator für die Mächtigkeit des zu brechenden Spruchs">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_verwandlung_rep">
+						<select type="text" name="attr_z_verwandlungbeenden_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16094,7 +16094,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Wand_aus_Flammen_rep">
+						<select type="text" name="attr_z_wandausflammen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16123,7 +16123,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/IN</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_warmes_rep">
+						<select type="text" name="attr_z_warmesblut_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16152,7 +16152,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Warmes_gefriere_rep">
+						<select type="text" name="attr_z_warmesgefriere_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16210,7 +16210,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Wasserwall_rep">
+						<select type="text" name="attr_z_wasserwall_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16239,7 +16239,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_weiches_rep">
+						<select type="text" name="attr_z_weicheserstarre_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16297,7 +16297,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KO + <span class="abbr" title="1 pro Woche Wirkungsdauer">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_weisheit_rep">
+						<select type="text" name="attr_z_weisheitderbaeume_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16355,7 +16355,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_weisse_rep">
+						<select type="text" name="attr_z_weissemaehn_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16471,7 +16471,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Windbarriere_rep">
+						<select type="text" name="attr_z_windbarriere_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16500,7 +16500,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/IN/IN</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Windgefluester_rep">
+						<select type="text" name="attr_z_windgefluester_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16529,7 +16529,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/KK</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Windhose_rep">
+						<select type="text" name="attr_z_windhose_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16558,7 +16558,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">KL/CH/KK + <span class="abbr" title="Modifikator für die vorherrschende Windstärke">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Windstille_rep">
+						<select type="text" name="attr_z_windstille_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16587,7 +16587,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/IN/GE</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Wipfellauf_rep">
+						<select type="text" name="attr_z_wipfellauf_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16674,7 +16674,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">IN/IN/FF</div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Zappenduster_rep">
+						<select type="text" name="attr_z_zappenduster_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16819,7 +16819,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/KO + <span class="abbr" title="Modifikator für die Elementspezialisierung">Mod.</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_zorn_rep">
+						<select type="text" name="attr_z_zornderelemente_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16848,7 +16848,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/CH/FF + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_zunge_rep">
+						<select type="text" name="attr_z_zungelaehmen_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -16877,7 +16877,7 @@
 					</div>
 					<div class="talent-cell talent-eigenschaften">MU/KL/CH + <span class="abbr" title="Magieresistenz">MR</span></div>
 					<div class="talent-cell talent-rep">
-						<select type="text" name="attr_z_Zwingtanz_rep">
+						<select type="text" name="attr_z_zwingtanz_rep">
 							<option value="">---</option>
 							<option value="Mag">Mag</option>
 							<option value="Elf">Elf</option>
@@ -28324,16 +28324,21 @@ on(talents_ebe.map(talent => "clicked:" + talent + "-ebe-action").join(" "), asy
 });
 /* talents end */
 /* magic begin */
-function modifySpellAttributesByRepresentation(spellRepAttr, charData, spellAttrs) {
+function modifySpellAttributesByRepresentation(spellRepStat, charData, spellStats) {
 	/* deal with representation special rules:
 		if representation is elven and KL < IN, replace first KL with IN, unless that would make all rolls IN 
 		if rep is achaz and two rolls are for KL or two are for IN, replace one of them with max(KL, IN)
-		if rep is kophtan, and KL < CH, replace first KL with CH, unless that would make all rolls IN
+		if rep is kophtan, and KL < CH, replace first KL with CH, unless that would make all rolls CH
 	*/
 	const func = "Attribute modification by spell representation";
-	let spellRep = (charData[spellRepAttr] === 0 || charData[spellRepAttr] === "")? charData["z_erstrepraesentation"] : charData[spellRepAttr];
-	debugLog(func, spellRep, charData, spellAttrs);
+	let spellRep = "";
 	let modified = false;
+	if (charData[spellRepStat] === 0 || charData[spellRepStat] === "") {
+		spellRep = charData["z_erstrepraesentation"];
+	} else {
+		spellRep = charData[spellRepStat];
+	}
+	debugLog(func, spellRep, charData, spellStats);
 	switch (spellRep) {
 		case "Elf":
 			debugLog(func, "Adapting for elven rep");
@@ -28341,8 +28346,8 @@ function modifySpellAttributesByRepresentation(spellRepAttr, charData, spellAttr
 				break;
 			}
 			for (let i = 0; i < 3; i++) {
-				if (spellAttrs[i] === "KL" && (spellAttrs[(i+1) % 3] !== "IN" || spellAttrs[(i + 2) % 3] !== "IN")) {
-					spellAttrs[i] = "IN";
+				if (spellStats[i] === "KL" && (spellStats[(i+1) % 3] !== "IN" || spellStats[(i + 2) % 3] !== "IN")) {
+					spellStats[i] = "IN";
 					modified = true;
 					break;
 				}
@@ -28350,18 +28355,36 @@ function modifySpellAttributesByRepresentation(spellRepAttr, charData, spellAttr
 			break;
 		case "Ach":
 			debugLog(func, "Adapting for achaz rep");
-			let doubleAttr = "";
-			if ((spellAttrs[0] === "KL" || spellAttrs[0] === "IN") && (spellAttrs[1] === spellAttrs[0] || spellAttrs[2] === spellAttrs[0])) {
-					doubleAttr = spellAttrs[0];
+			// Stat occurring at least twice
+			let multiStat = "";
+			// Stat occuring once or zero times, the stat that shall be checked for replacing one instance of the multiStat
+			let otherStat = "";
+
+			const relevantStats = [ "KL", "IN" ];
+			let spellStatFreq = { "KL": 0, "IN": 0 };
+			// Analyse spell's stats looking for our relevant ones
+			for (let spellStat of spellStats) {
+				if (relevantStats.includes(spellStat)) {
+					spellStatFreq[spellStat] += 1;
+				}
 			}
-			else if (doubleAttr === "" && (spellAttrs[1] === "KL" || spellAttrs[1] === "IN") && spellAttrs[1] === spellAttrs[2]) {
-					doubleAttr = spellAttrs[1];
+
+			// Determine whether spell has potentially beneficial stat situation
+			for (let stat of relevantStats){
+				if (spellStatFreq[stat] >= 2) {
+					multiStat = stat;
+				} else {
+					otherStat = stat;
+				}
 			}
-			let otherAttr = doubleAttr === "KL" ? "IN" : "KL";
-			if (doubleAttr !== "" && charData[doubleAttr] < charData[otherAttr]) {
-				for (let i = 0; i < 3; i++) {
-					if (spellAttrs[i] === doubleAttr) {
-						spellAttrs[i] = otherAttr;
+
+			// No stat occurring at least twice? No replacement possible, so break
+			if (multiStat === "") break;
+
+			if (charData[multiStat] > charData[otherStat]) {
+				for (let i in spellStats) {
+					if (spellStats[i] === multiStat) {
+						spellStats[i] = otherStat;
 						modified = true;
 						break;
 					}
@@ -28374,8 +28397,8 @@ function modifySpellAttributesByRepresentation(spellRepAttr, charData, spellAttr
 				break;
 			}
 			for (let i = 0; i < 3; i++) {
-				if (spellAttrs[i] === "KL" && (spellAttrs[(i+1) % 3] !== "CH" || spellAttrs[(i + 2) % 3] !== "CH")) {
-					spellAttrs[i] = "CH";
+				if (spellStats[i] === "KL" && (spellStats[(i+1) % 3] !== "CH" || spellStats[(i + 2) % 3] !== "CH")) {
+					spellStats[i] = "CH";
 					modified = true;
 					break;
 				}
@@ -28392,6 +28415,7 @@ on(spells.map(spell => "clicked:" + spell + "-action").join(" "), (info) => {
 	var trigger = info["triggerName"].replace(/clicked:([^-]+)-action/, '$1');
 	var nameInternal = spellsData[trigger]["internal"];
 	var nameUI = spellsData[trigger]["ui"];
+	//Copy array, or we get a reference and modify the database
 	var stats = [...spellsData[trigger]["stats"]];
 	var spellRepAttr = trigger + "_rep";
 	debugLog(func, trigger, spellsData[trigger]);
@@ -28513,7 +28537,8 @@ on(spells.map(spell => "clicked:" + spell + "-action").join(" "), (info) => {
 						(rolls[1] === rolls[2]) ||
 						(rolls[2] === rolls[0])
 					)
-				) {
+				)
+				{
 					criticality = -4;
 				}
 			}
@@ -28546,8 +28571,8 @@ on(spells.map(spell => "clicked:" + spell + "-action").join(" "), (info) => {
 					TaPstar -= Math.max(0, effRolls[roll] - stats[roll]);
 				}
 
-				// Max. TaP* = TaW
-				TaPstar = Math.min(TaW, TaPstar);
+				// Max. TaP* = TaW, mindestens aber 0
+				TaPstar = Math.min(Math.max(TaW, 0), TaPstar);
 
 				// Ergebnis an Doppel/Dreifach-20 anpassen
 				if (Math.abs(criticality) <= 1)

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -21162,7 +21162,7 @@
 	</div>
 <!-- sheet section info end -->
 <!-- sheet footer start -->
-	<b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="stat-immutable stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20240414"><input type="hidden" class="stat-immutable stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
+	<b>&bdquo;Das Schwarze Auge&ldquo;-Heldenbogen für Roll20.net, Version <input type="text" class="stat-immutable stat-immutable-version" disabled="disabled" name="attr_character_sheet_version" value="20240421"><input type="hidden" class="stat-immutable stat-immutable-version" readonly="readonly" name="attr_data_version" value=""></b>
 <!-- sheet footer end -->
 </div>
 <!-- sheet end -->
@@ -26671,7 +26671,7 @@ var versionsWithMigrations = [
 		20220604,
 		20220821,
 		20230618,
-		20240414
+		20240414,
 		20240421
 ];
 
@@ -27565,7 +27565,7 @@ function migrateTo20240414(migrationChain) {
 }
 
 /*
-	Migration steps: rename attribute subtag1 to z_repraesentation and map its value
+	Migration steps: rename attribute subtag1 to z_erstrepraesentation and map its value
 */
 function migrateTo20240421(migrationChain) {
 	var caller = "migrateTo20240421";
@@ -27584,7 +27584,7 @@ function migrateTo20240421(migrationChain) {
 	}
 	safeGetAttrs(["subtag1"], function (v) {
 		let attrsToChange = {
-			"z_erstrepraesentation": valueMap[v[subtag1]]
+			"z_erstrepraesentation": valueMap[v["subtag1"]]
 		}
 		safeSetAttrs(attrsToChange, {}, function () {
 			callNextMigration(migrationChain);
@@ -28326,9 +28326,9 @@ on(talents_ebe.map(talent => "clicked:" + talent + "-ebe-action").join(" "), asy
 /* magic begin */
 function modifySpellAttributesByRepresentation(spellRepAttr, charData, spellAttrs) {
 	/* deal with representation special rules:
-		if representation is elven and KL > IN, replace first KL with IN 
+		if representation is elven and KL < IN, replace first KL with IN, unless that would make all rolls IN 
 		if rep is achaz and two rolls are for KL or two are for IN, replace one of them with max(KL, IN)
-		if rep is kophtan, do something
+		if rep is kophtan, and KL < CH, replace first KL with CH, unless that would make all rolls IN
 	*/
 	const func = "Attribute modification by spell representation";
 	let spellRep = (charData[spellRepAttr] === 0 || charData[spellRepAttr] === "")? charData["z_erstrepraesentation"] : charData[spellRepAttr];
@@ -28337,7 +28337,7 @@ function modifySpellAttributesByRepresentation(spellRepAttr, charData, spellAttr
 	switch (spellRep) {
 		case "Elf":
 			debugLog(func, "Adapting for elven rep");
-			if (charData['KL'] > charData['IN']) {
+			if (charData['KL'] >= charData['IN']) {
 				break;
 			}
 			for (let i = 0; i < 3; i++) {
@@ -28351,16 +28351,13 @@ function modifySpellAttributesByRepresentation(spellRepAttr, charData, spellAttr
 		case "Ach":
 			debugLog(func, "Adapting for achaz rep");
 			let doubleAttr = "";
-			if (spellAttrs[0] === "KL" || spellAttrs[0] === "IN") {
-				if	(spellAttrs[1] === spellAttrs[0] || spellAttrs[2] === spellAttrs[0]) {
+			if ((spellAttrs[0] === "KL" || spellAttrs[0] === "IN") && (spellAttrs[1] === spellAttrs[0] || spellAttrs[2] === spellAttrs[0])) {
 					doubleAttr = spellAttrs[0];
-				}
-			} else {
-				if ((spellAttrs[1] === "KL" || spellAttrs[1] === "IN") && spellAttrs[1] === spellAttrs[2]) {
-					doubleAttr = spellAttrs[1];
-				}
 			}
-			let otherAttr = doubleAttr === "KL" ? "IN" : "KL"
+			else if (doubleAttr === "" && (spellAttrs[1] === "KL" || spellAttrs[1] === "IN") && spellAttrs[1] === spellAttrs[2]) {
+					doubleAttr = spellAttrs[1];
+			}
+			let otherAttr = doubleAttr === "KL" ? "IN" : "KL";
 			if (doubleAttr !== "" && charData[doubleAttr] < charData[otherAttr]) {
 				for (let i = 0; i < 3; i++) {
 					if (spellAttrs[i] === doubleAttr) {
@@ -28368,13 +28365,21 @@ function modifySpellAttributesByRepresentation(spellRepAttr, charData, spellAttr
 						modified = true;
 						break;
 					}
-					
 				}
 			}
 			break;
 		case "Kop":
 			debugLog(func, "Adapting for kophtan rep");
-			//TODO
+			if (charData['KL'] >= charData['CH']) {
+				break;
+			}
+			for (let i = 0; i < 3; i++) {
+				if (spellAttrs[i] === "KL" && (spellAttrs[(i+1) % 3] !== "CH" || spellAttrs[(i + 2) % 3] !== "CH")) {
+					spellAttrs[i] = "CH";
+					modified = true;
+					break;
+				}
+			}
 			break;
 		default:
 			break;
@@ -28387,7 +28392,7 @@ on(spells.map(spell => "clicked:" + spell + "-action").join(" "), (info) => {
 	var trigger = info["triggerName"].replace(/clicked:([^-]+)-action/, '$1');
 	var nameInternal = spellsData[trigger]["internal"];
 	var nameUI = spellsData[trigger]["ui"];
-	var stats = spellsData[trigger]["stats"];
+	var stats = [...spellsData[trigger]["stats"]];
 	var spellRepAttr = trigger + "_rep";
 	debugLog(func, trigger, spellsData[trigger]);
 	safeGetAttrs(["z_erstrepraesentation", spellRepAttr, "v_festematrix", "n_spruchhemmung", "KL", "IN", "CH"], function (v) {


### PR DESCRIPTION
Hiermit werden wenn elfische Repräsentation ausgewählt ist, KL kleiner als IN ist und nicht bereits zweimal auf IN gewürfelt wird, der erste KL Wurf durch einen IN Wurf ersetzt.

Außerdem habe ich das Repräsentationsdropdown mit den Kurznamen der Repräsentationen aus LC versehen und ihm einen sprechenderen Namen gegeben. Die relevante Migration dazu ist ausdrücklich ungetestet, der Rest ist in der Sandbox getestet und funktioniert.