### PR TITLE
Refactor/talents duplication

### DIFF
--- a/Das_Schwarze_Auge_4-1/dev/js/talents.js
+++ b/Das_Schwarze_Auge_4-1/dev/js/talents.js
@@ -1,4 +1,128 @@
 /* talents begin */
+
+function generatTalentRollMacro(template, systemName, readableName, attributes, ebeMacro="") {
+	let rollMacro = 
+		"@{gm_roll_opt} " +
+		"&{template:" + template + "} " +
+		"{{name=" + readableName + "}} " +
+		"{{wert=[[@{TaW_" + systemName + "}d1cs0cf2]]}} " +
+		"{{mod=" +
+			(ebeMacro === "" ?
+				"[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]" : 
+				"[[ 0d1 + ?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2 + [[{0d1 + " + ebeMacro + ", 0d1}kh1]]d1cs0cf2 ]]"
+			) +
+		"}} " +
+		"{{stats=[[ " +
+			"[Eigenschaft 1:] [[@{"+ attributes[0] +"}]]d1cs0cf2 + " +
+			"[Eigenschaft 2:] [[@{"+ attributes[1] +"}]]d1cs0cf2 + " +
+			"[Eigenschaft 3:] [[@{"+ attributes[2] +"}]]d1cs0cf2" +
+		"]]}} " +
+		"{{roll=[[3d20cs<@{cs_talent}cf>@{cf_talent}]]}} " +
+		"{{result=[[0]]}} " +
+		"{{criticality=[[0]]}} " +
+		"{{critThresholds=[[[[@{cs_talent}]]d1cs0cf2 + [[@{cf_talent}]]d1cs0cf2]]}} ";
+	if (ebeMacro !== "") {
+		rollMacro += "{{ebe=[[{0d1 + " + ebeMacro + ", 0d1}kh1]]}} ";
+	}
+	return rollMacro;
+}
+
+function getTalentRollResults(results) {
+	var stats = [
+		results.stats.rolls[0].dice,
+		results.stats.rolls[1].dice,
+		results.stats.rolls[2].dice
+	];
+	var TaW = results.wert.result;
+	var mod = results.mod.result;
+	var rolls = results.roll.rolls[0].results;
+	var success = results.critThresholds.rolls[0].dice;
+	var failure = results.critThresholds.rolls[1].dice;
+	/* Result
+	0	Failure
+	1	Success
+	*/
+	var result = 0;
+	/* Criticality
+	-3	Triple 20
+	-2	Double 20
+	 0	no double 1/20
+	+2	Double 1
+	+3	Triple 1
+	*/
+	var criticality = 0;
+
+	/*
+		Doppel/Dreifach-1/20-Berechnung
+		Vor der TaP*-Berechnung, da diese damit gegebenenfalls hinfällig wird
+	*/
+	{
+		let successes = 0;
+		let failures = 0;
+		for (roll of rolls)
+		{
+			if (roll <= success)
+			{
+				successes += 1;
+			} else if (roll >= failure) {
+				failures += 1;
+			}
+			if (successes >= 2)
+			{
+				criticality = successes;
+			} else if (failures >= 2) {
+				criticality = -failures;
+			}
+		}
+	}
+
+	/*
+		TaP*-Berechnung
+	*/
+	var effRolls = rolls;
+	var effTaW = TaW - mod;
+	var TaPstar = effTaW;
+
+	// Negativer TaW: |effTaW| zu Teilwürfen addieren
+	if (criticality >= 2)
+	{
+		TaPstar = TaW;
+		result = 1;
+	} else {
+		if (effTaW < 0)
+		{
+			for (roll in rolls)
+			{
+				effRolls[roll] = rolls[roll] + Math.abs(effTaW);
+			}
+			TaPstar = 0;
+		}
+
+		// TaP-Verbrauch für jeden Wurf
+		for (roll in effRolls)
+		{
+			TaPstar -= Math.max(0, effRolls[roll] - stats[roll]);
+		}
+
+		// Max. TaP* = TaW
+		TaPstar = Math.min(Math.max(0, TaW), TaPstar);
+
+		// Ergebnis an Doppel/Dreifach-20 anpassen
+		if (Math.abs(criticality) <= 1)
+		{
+			result = TaPstar < 0 ? 0 : 1;
+		} else if (criticality <= -2) {
+			result = 0;
+		}
+	}
+	return {
+		"result" : result,
+		"TaPstar": TaPstar,
+		"criticality": criticality,
+		"stats": stats,
+	};
+}
+
 on("change:repeating_gaben:name_gabe change:repeating_gaben:name_gabe_zusatz", function(eventInfo) {
 		safeGetAttrs(["repeating_Gaben_Name_Gabe", "repeating_Gaben_Name_Gabe_Zusatz"], function(v) {
 				let gabe = v.repeating_Gaben_Name_Gabe;
@@ -129,46 +253,18 @@ on(talents.map(talent => "clicked:" + talent + "-action").join(" "), async (info
 	var nameInternal = talentsData[trigger]["internal"];
 	var nameUI = talentsData[trigger]["ui"];
 	debugLog(func, trigger, talentsData[trigger]);
-
-	// Build Roll Macro
-	var rollMacro = "";
-
-	rollMacro +=
-		"@{gm_roll_opt} " +
-		"&{template:talent} " +
-		"{{name=" + nameUI + "}} " +
-		"{{wert=[[@{TaW_" + nameInternal + "}d1cs0cf2]]}} " +
-		"{{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} ";
+	let attributes = [];
 	// All languages (sp) and scripts (sc) use the same attributes, so no layer of indirection via talent name required/possible.
 	if (trigger.replace(/t_([^_]+)_.*/, '$1') === "sp")
 	{
-		rollMacro +=
-		"{{stats=[[ " +
-			"[Eigenschaft 1:] [[@{KL}]]d1cs0cf2 + " +
-			"[Eigenschaft 2:] [[@{IN}]]d1cs0cf2 + " +
-			"[Eigenschaft 3:] [[@{CH}]]d1cs0cf2" +
-			"]]}} ";
+		attributes = ["KL", "IN", "CH"];
 	} else if (trigger.replace(/t_([^_]+)_.*/, '$1') === "sc") {
-		rollMacro +=
-		"{{stats=[[ " +
-			"[Eigenschaft 1:] [[@{KL}]]d1cs0cf2 + " +
-			"[Eigenschaft 2:] [[@{KL}]]d1cs0cf2 + " +
-			"[Eigenschaft 3:] [[@{FF}]]d1cs0cf2" +
-			"]]}} ";
+		attributes = ["KL", "KL", "FF"];
 	} else {
-		rollMacro +=
-		"{{stats=[[ " +
-			"[Eigenschaft 1:] [[@{Eigenschaft1" + nameInternal + "}]]d1cs0cf2 + " +
-			"[Eigenschaft 2:] [[@{Eigenschaft2" + nameInternal + "}]]d1cs0cf2 + " +
-			"[Eigenschaft 3:] [[@{Eigenschaft3" + nameInternal + "}]]d1cs0cf2" +
-			"]]}} ";
-	}
+		attributes = ["Eigenschaft1" + nameInternal, "Eigenschaft2" + nameInternal, "Eigenschaft3" + nameInternal];
 
-	rollMacro +=
-		"{{roll=[[3d20cs<@{cs_talent}cf>@{cf_talent}]]}} " +
-		"{{result=[[0]]}} " +
-		"{{criticality=[[0]]}} " +
-		"{{critThresholds=[[[[@{cs_talent}]]d1cs0cf2 + [[@{cf_talent}]]d1cs0cf2]]}} ";
+	}
+	let rollMacro = generateTalentRollMacro("talent", nameInternal, nameUI, attributes);
 	debugLog(func, rollMacro);
 
 	// Execute Roll
@@ -176,103 +272,17 @@ on(talents.map(talent => "clicked:" + talent + "-action").join(" "), async (info
 	debugLog(func, "test: info:", info, "results:", results);
 
 	// Process Roll
-	var rollID = results.rollId;
+	let rollID = results.rollId;
 	results = results.results;
-	var TaW = results.wert.result;
-	var mod = results.mod.result;
-	var stats = [
-		results.stats.rolls[0].dice,
-		results.stats.rolls[1].dice,
-		results.stats.rolls[2].dice
-	];
-	var rolls = results.roll.rolls[0].results;
-	var success = results.critThresholds.rolls[0].dice;
-	var failure = results.critThresholds.rolls[1].dice;
-	/* Result
-	0	Failure
-	1	Success
-	*/
-	var result = 0;
-	/* Criticality
-	-3	Triple 20
-	-2	Double 20
-	 0	no double 1/20
-	+2	Double 1
-	+3	Triple 1
-	*/
-	var criticality = 0;
-
-	/*
-		Doppel/Dreifach-1/20-Berechnung
-		Vor der TaP*-Berechnung, da diese damit gegebenenfalls hinfällig wird
-	*/
-	{
-		let successes = 0;
-		let failures = 0;
-		for (roll of rolls)
-		{
-			if (roll <= success)
-			{
-				successes += 1;
-			} else if (roll >= failure) {
-				failures += 1;
-			}
-			if (successes >= 2)
-			{
-				criticality = successes;
-			} else if (failures >= 2) {
-				criticality = -failures;
-			}
-		}
-	}
-
-	/*
-		TaP*-Berechnung
-	*/
-	var effRolls = rolls;
-	var effTaW = TaW - mod;
-	var TaPstar = effTaW;
-
-	// Negativer TaW: |effTaW| zu Teilwürfen addieren
-	if (criticality >= 2)
-	{
-		TaPstar = TaW;
-		result = 1;
-	} else {
-		if (effTaW < 0)
-		{
-			for (roll in rolls)
-			{
-				effRolls[roll] = rolls[roll] + Math.abs(effTaW);
-			}
-			TaPstar = 0;
-		}
-
-		// TaP-Verbrauch für jeden Wurf
-		for (roll in effRolls)
-		{
-			TaPstar -= Math.max(0, effRolls[roll] - stats[roll]);
-		}
-
-		// Max. TaP* = TaW, mindestens aber 0
-		TaPstar = Math.min(Math.max(TaW, 0), TaPstar);
-
-		// Ergebnis an Doppel/Dreifach-20 anpassen
-		if (Math.abs(criticality) <= 1)
-		{
-			result = TaPstar < 0 ? 0 : 1;
-		} else if (criticality <= -2) {
-			result = 0;
-		}
-	}
+	let processedResult = getTalentRollResults(results);
 
 	finishRoll(
 		rollID,
 		{
-			roll: TaPstar,
-			result: result,
-			criticality: criticality,
-			stats: stats.toString().replaceAll(",", "/")
+			roll: processedResult.TaPstar,
+			result: processedResult.result,
+			criticality: processedResult.criticality,
+			stats: processedResult.stats.toString().replaceAll(",", "/")
 		}
 	);
 });
@@ -284,142 +294,40 @@ on(talents_ebe.map(talent => "clicked:" + talent + "-ebe-action").join(" "), asy
 	var nameUI = talentsData[trigger]["ui"];
 	debugLog(func, trigger, talentsData[trigger]);
 
-	// Build Roll Macro
-	var rollMacro = "";
+	let attributes = ["Eigenschaft1" + nameInternal, "Eigenschaft2" + nameInternal, "Eigenschaft3" + nameInternal];
+
 	var ebeMacro = "@{BE}";
 	var talentEbeData = effectiveEncumbrance[trigger];
-	console.log(talentEbeData);
 	if (talentEbeData["type"] === "factor")
 	{
 		ebeMacro = talentEbeData["value"].toString() + " * " + ebeMacro;
 	} else if (talentEbeData["type"] === "summand") {
 		ebeMacro += talentEbeData["value"].toString();
 	}
+	let rollMacro = generateTalentRollMacro("talent-ebe", nameInternal, nameUI, attributes, ebeMacro);
 
-	rollMacro +=
-		"@{gm_roll_opt} " +
-		"&{template:talent-ebe} " +
-		"{{name=" + nameUI + "}} " +
-		"{{wert=[[@{TaW_" + nameInternal + "}d1cs0cf2]]}} " +
-		"{{mod=[[ 0d1 + ?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2 + [[{0d1 + " + ebeMacro + ", 0d1}kh1]]d1cs0cf2 ]]}} " +
-		"{{stats=[[ " +
-			"[Eigenschaft 1:] [[@{Eigenschaft1" + nameInternal + "}]]d1cs0cf2 + " +
-			"[Eigenschaft 2:] [[@{Eigenschaft2" + nameInternal + "}]]d1cs0cf2 + " +
-			"[Eigenschaft 3:] [[@{Eigenschaft3" + nameInternal + "}]]d1cs0cf2" +
-			"]]}} " +
-		"{{roll=[[3d20cs<@{cs_talent}cf>@{cf_talent}]]}} " +
-		"{{result=[[0]]}} " +
-		"{{criticality=[[0]]}} " +
-		"{{critThresholds=[[[[@{cs_talent}]]d1cs0cf2 + [[@{cf_talent}]]d1cs0cf2]]}} " +
-		"{{ebe=[[{0d1 + " + ebeMacro + ", 0d1}kh1]]}} ";
 	debugLog(func, rollMacro);
 
 	// Execute Roll
 	results = await startRoll(rollMacro);
 	debugLog(func, "test: info:", info, "results:", results);
 
+
 	// Process Roll
-	var rollID = results.rollId;
+	let rollID = results.rollId;
 	results = results.results;
-	var TaW = results.wert.result;
-	var modTotal = results.mod.result;
 	var ebe = results.ebe.result;
-	var modOnly = modTotal - ebe;
-
-	var stats = [
-		results.stats.rolls[0].dice,
-		results.stats.rolls[1].dice,
-		results.stats.rolls[2].dice
-	];
-	var rolls = results.roll.rolls[0].results;
-	var success = results.critThresholds.rolls[0].dice;
-	var failure = results.critThresholds.rolls[1].dice;
-	/* Result
-	0	Failure
-	1	Success
-	*/
-	var result = 0;
-	/* Criticality
-	-3	Triple 20
-	-2	Double 20
-	 0	no double 1/20
-	+2	Double 1
-	+3	Triple 1
-	*/
-	var criticality = 0;
-
-	/*
-		Doppel/Dreifach-1/20-Berechnung
-		Vor der TaP*-Berechnung, da diese damit gegebenenfalls hinfällig wird
-	*/
-	{
-		let successes = 0;
-		let failures = 0;
-		for (roll of rolls)
-		{
-			if (roll <= success)
-			{
-				successes += 1;
-			} else if (roll >= failure) {
-				failures += 1;
-			}
-			if (successes >= 2)
-			{
-				criticality = successes;
-			} else if (failures >= 2) {
-				criticality = -failures;
-			}
-		}
-	}
-
-	/*
-		TaP*-Berechnung
-	*/
-	var effRolls = rolls;
-	var effTaW = TaW - modTotal;
-	var TaPstar = effTaW;
-
-	// Negativer TaW: |effTaW| zu Teilwürfen addieren
-	if (criticality >= 2)
-	{
-		TaPstar = TaW;
-		result = 1;
-	} else {
-		if (effTaW < 0)
-		{
-			for (roll in rolls)
-			{
-				effRolls[roll] = rolls[roll] + Math.abs(effTaW);
-			}
-			TaPstar = 0;
-		}
-
-		// TaP-Verbrauch für jeden Wurf
-		for (roll in effRolls)
-		{
-			TaPstar -= Math.max(0, effRolls[roll] - stats[roll]);
-		}
-
-		// Max. TaP* = TaW, mindestens aber 0
-		TaPstar = Math.min(Math.max(TaW, 0), TaPstar);
-
-		// Ergebnis an Doppel/Dreifach-20 anpassen
-		if (Math.abs(criticality) <= 1)
-		{
-			result = TaPstar < 0 ? 0 : 1;
-		} else if (criticality <= -2) {
-			result = 0;
-		}
-	}
+	var modOnly = results.mod.result - ebe;
+	let processedResult = getTalentRollResults(results);
 
 	finishRoll(
 		rollID,
 		{
 			mod: modOnly,
-			roll: TaPstar,
-			result: result,
-			criticality: criticality,
-			stats: stats.toString().replaceAll(",", "/")
+			roll: processedResult.TaPstar,
+			result: processedResult.result,
+			criticality: processedResult.criticality,
+			stats: processedResult.stats.toString().replaceAll(",", "/")
 		}
 	);
 });

--- a/Das_Schwarze_Auge_4-1/dev/js/talents.js
+++ b/Das_Schwarze_Auge_4-1/dev/js/talents.js
@@ -1,6 +1,6 @@
 /* talents begin */
 
-function generatTalentRollMacro(template, systemName, readableName, attributes, ebeMacro="") {
+function generateTalentRollMacro(template, systemName, readableName, attributes, ebeMacro="") {
 	let rollMacro = 
 		"@{gm_roll_opt} " +
 		"&{template:" + template + "} " +

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -1767,4 +1767,3 @@ upper left, upper right, lower right, lower left */
     color: var(--color-foreground) !important;
 }
 
-

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -22396,7 +22396,7 @@ on(
 /* advantages disadvantages end */
 /* talents begin */
 
-function generatTalentRollMacro(template, systemName, readableName, attributes, ebeMacro="") {
+function generateTalentRollMacro(template, systemName, readableName, attributes, ebeMacro="") {
 	let rollMacro = 
 		"@{gm_roll_opt} " +
 		"&{template:" + template + "} " +

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -22395,6 +22395,130 @@ on(
 });
 /* advantages disadvantages end */
 /* talents begin */
+
+function generatTalentRollMacro(template, systemName, readableName, attributes, ebeMacro="") {
+	let rollMacro = 
+		"@{gm_roll_opt} " +
+		"&{template:" + template + "} " +
+		"{{name=" + readableName + "}} " +
+		"{{wert=[[@{TaW_" + systemName + "}d1cs0cf2]]}} " +
+		"{{mod=" +
+			(ebeMacro === "" ?
+				"[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]" : 
+				"[[ 0d1 + ?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2 + [[{0d1 + " + ebeMacro + ", 0d1}kh1]]d1cs0cf2 ]]"
+			) +
+		"}} " +
+		"{{stats=[[ " +
+			"[Eigenschaft 1:] [[@{"+ attributes[0] +"}]]d1cs0cf2 + " +
+			"[Eigenschaft 2:] [[@{"+ attributes[1] +"}]]d1cs0cf2 + " +
+			"[Eigenschaft 3:] [[@{"+ attributes[2] +"}]]d1cs0cf2" +
+		"]]}} " +
+		"{{roll=[[3d20cs<@{cs_talent}cf>@{cf_talent}]]}} " +
+		"{{result=[[0]]}} " +
+		"{{criticality=[[0]]}} " +
+		"{{critThresholds=[[[[@{cs_talent}]]d1cs0cf2 + [[@{cf_talent}]]d1cs0cf2]]}} ";
+	if (ebeMacro !== "") {
+		rollMacro += "{{ebe=[[{0d1 + " + ebeMacro + ", 0d1}kh1]]}} ";
+	}
+	return rollMacro;
+}
+
+function getTalentRollResults(results) {
+	var stats = [
+		results.stats.rolls[0].dice,
+		results.stats.rolls[1].dice,
+		results.stats.rolls[2].dice
+	];
+	var TaW = results.wert.result;
+	var mod = results.mod.result;
+	var rolls = results.roll.rolls[0].results;
+	var success = results.critThresholds.rolls[0].dice;
+	var failure = results.critThresholds.rolls[1].dice;
+	/* Result
+	0	Failure
+	1	Success
+	*/
+	var result = 0;
+	/* Criticality
+	-3	Triple 20
+	-2	Double 20
+	 0	no double 1/20
+	+2	Double 1
+	+3	Triple 1
+	*/
+	var criticality = 0;
+
+	/*
+		Doppel/Dreifach-1/20-Berechnung
+		Vor der TaP*-Berechnung, da diese damit gegebenenfalls hinfällig wird
+	*/
+	{
+		let successes = 0;
+		let failures = 0;
+		for (roll of rolls)
+		{
+			if (roll <= success)
+			{
+				successes += 1;
+			} else if (roll >= failure) {
+				failures += 1;
+			}
+			if (successes >= 2)
+			{
+				criticality = successes;
+			} else if (failures >= 2) {
+				criticality = -failures;
+			}
+		}
+	}
+
+	/*
+		TaP*-Berechnung
+	*/
+	var effRolls = rolls;
+	var effTaW = TaW - mod;
+	var TaPstar = effTaW;
+
+	// Negativer TaW: |effTaW| zu Teilwürfen addieren
+	if (criticality >= 2)
+	{
+		TaPstar = TaW;
+		result = 1;
+	} else {
+		if (effTaW < 0)
+		{
+			for (roll in rolls)
+			{
+				effRolls[roll] = rolls[roll] + Math.abs(effTaW);
+			}
+			TaPstar = 0;
+		}
+
+		// TaP-Verbrauch für jeden Wurf
+		for (roll in effRolls)
+		{
+			TaPstar -= Math.max(0, effRolls[roll] - stats[roll]);
+		}
+
+		// Max. TaP* = TaW
+		TaPstar = Math.min(Math.max(0, TaW), TaPstar);
+
+		// Ergebnis an Doppel/Dreifach-20 anpassen
+		if (Math.abs(criticality) <= 1)
+		{
+			result = TaPstar < 0 ? 0 : 1;
+		} else if (criticality <= -2) {
+			result = 0;
+		}
+	}
+	return {
+		"result" : result,
+		"TaPstar": TaPstar,
+		"criticality": criticality,
+		"stats": stats,
+	};
+}
+
 on("change:repeating_gaben:name_gabe change:repeating_gaben:name_gabe_zusatz", function(eventInfo) {
 		safeGetAttrs(["repeating_Gaben_Name_Gabe", "repeating_Gaben_Name_Gabe_Zusatz"], function(v) {
 				let gabe = v.repeating_Gaben_Name_Gabe;
@@ -22525,46 +22649,18 @@ on(talents.map(talent => "clicked:" + talent + "-action").join(" "), async (info
 	var nameInternal = talentsData[trigger]["internal"];
 	var nameUI = talentsData[trigger]["ui"];
 	debugLog(func, trigger, talentsData[trigger]);
-
-	// Build Roll Macro
-	var rollMacro = "";
-
-	rollMacro +=
-		"@{gm_roll_opt} " +
-		"&{template:talent} " +
-		"{{name=" + nameUI + "}} " +
-		"{{wert=[[@{TaW_" + nameInternal + "}d1cs0cf2]]}} " +
-		"{{mod=[[?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2]]}} ";
+	let attributes = [];
 	// All languages (sp) and scripts (sc) use the same attributes, so no layer of indirection via talent name required/possible.
 	if (trigger.replace(/t_([^_]+)_.*/, '$1') === "sp")
 	{
-		rollMacro +=
-		"{{stats=[[ " +
-			"[Eigenschaft 1:] [[@{KL}]]d1cs0cf2 + " +
-			"[Eigenschaft 2:] [[@{IN}]]d1cs0cf2 + " +
-			"[Eigenschaft 3:] [[@{CH}]]d1cs0cf2" +
-			"]]}} ";
+		attributes = ["KL", "IN", "CH"];
 	} else if (trigger.replace(/t_([^_]+)_.*/, '$1') === "sc") {
-		rollMacro +=
-		"{{stats=[[ " +
-			"[Eigenschaft 1:] [[@{KL}]]d1cs0cf2 + " +
-			"[Eigenschaft 2:] [[@{KL}]]d1cs0cf2 + " +
-			"[Eigenschaft 3:] [[@{FF}]]d1cs0cf2" +
-			"]]}} ";
+		attributes = ["KL", "KL", "FF"];
 	} else {
-		rollMacro +=
-		"{{stats=[[ " +
-			"[Eigenschaft 1:] [[@{Eigenschaft1" + nameInternal + "}]]d1cs0cf2 + " +
-			"[Eigenschaft 2:] [[@{Eigenschaft2" + nameInternal + "}]]d1cs0cf2 + " +
-			"[Eigenschaft 3:] [[@{Eigenschaft3" + nameInternal + "}]]d1cs0cf2" +
-			"]]}} ";
-	}
+		attributes = ["Eigenschaft1" + nameInternal, "Eigenschaft2" + nameInternal, "Eigenschaft3" + nameInternal];
 
-	rollMacro +=
-		"{{roll=[[3d20cs<@{cs_talent}cf>@{cf_talent}]]}} " +
-		"{{result=[[0]]}} " +
-		"{{criticality=[[0]]}} " +
-		"{{critThresholds=[[[[@{cs_talent}]]d1cs0cf2 + [[@{cf_talent}]]d1cs0cf2]]}} ";
+	}
+	let rollMacro = generateTalentRollMacro("talent", nameInternal, nameUI, attributes);
 	debugLog(func, rollMacro);
 
 	// Execute Roll
@@ -22572,103 +22668,17 @@ on(talents.map(talent => "clicked:" + talent + "-action").join(" "), async (info
 	debugLog(func, "test: info:", info, "results:", results);
 
 	// Process Roll
-	var rollID = results.rollId;
+	let rollID = results.rollId;
 	results = results.results;
-	var TaW = results.wert.result;
-	var mod = results.mod.result;
-	var stats = [
-		results.stats.rolls[0].dice,
-		results.stats.rolls[1].dice,
-		results.stats.rolls[2].dice
-	];
-	var rolls = results.roll.rolls[0].results;
-	var success = results.critThresholds.rolls[0].dice;
-	var failure = results.critThresholds.rolls[1].dice;
-	/* Result
-	0	Failure
-	1	Success
-	*/
-	var result = 0;
-	/* Criticality
-	-3	Triple 20
-	-2	Double 20
-	 0	no double 1/20
-	+2	Double 1
-	+3	Triple 1
-	*/
-	var criticality = 0;
-
-	/*
-		Doppel/Dreifach-1/20-Berechnung
-		Vor der TaP*-Berechnung, da diese damit gegebenenfalls hinfällig wird
-	*/
-	{
-		let successes = 0;
-		let failures = 0;
-		for (roll of rolls)
-		{
-			if (roll <= success)
-			{
-				successes += 1;
-			} else if (roll >= failure) {
-				failures += 1;
-			}
-			if (successes >= 2)
-			{
-				criticality = successes;
-			} else if (failures >= 2) {
-				criticality = -failures;
-			}
-		}
-	}
-
-	/*
-		TaP*-Berechnung
-	*/
-	var effRolls = rolls;
-	var effTaW = TaW - mod;
-	var TaPstar = effTaW;
-
-	// Negativer TaW: |effTaW| zu Teilwürfen addieren
-	if (criticality >= 2)
-	{
-		TaPstar = TaW;
-		result = 1;
-	} else {
-		if (effTaW < 0)
-		{
-			for (roll in rolls)
-			{
-				effRolls[roll] = rolls[roll] + Math.abs(effTaW);
-			}
-			TaPstar = 0;
-		}
-
-		// TaP-Verbrauch für jeden Wurf
-		for (roll in effRolls)
-		{
-			TaPstar -= Math.max(0, effRolls[roll] - stats[roll]);
-		}
-
-		// Max. TaP* = TaW, mindestens aber 0
-		TaPstar = Math.min(Math.max(TaW, 0), TaPstar);
-
-		// Ergebnis an Doppel/Dreifach-20 anpassen
-		if (Math.abs(criticality) <= 1)
-		{
-			result = TaPstar < 0 ? 0 : 1;
-		} else if (criticality <= -2) {
-			result = 0;
-		}
-	}
+	let processedResult = getTalentRollResults(results);
 
 	finishRoll(
 		rollID,
 		{
-			roll: TaPstar,
-			result: result,
-			criticality: criticality,
-			stats: stats.toString().replaceAll(",", "/")
+			roll: processedResult.TaPstar,
+			result: processedResult.result,
+			criticality: processedResult.criticality,
+			stats: processedResult.stats.toString().replaceAll(",", "/")
 		}
 	);
 });
@@ -22680,142 +22690,40 @@ on(talents_ebe.map(talent => "clicked:" + talent + "-ebe-action").join(" "), asy
 	var nameUI = talentsData[trigger]["ui"];
 	debugLog(func, trigger, talentsData[trigger]);
 
-	// Build Roll Macro
-	var rollMacro = "";
+	let attributes = ["Eigenschaft1" + nameInternal, "Eigenschaft2" + nameInternal, "Eigenschaft3" + nameInternal];
+
 	var ebeMacro = "@{BE}";
 	var talentEbeData = effectiveEncumbrance[trigger];
-	console.log(talentEbeData);
 	if (talentEbeData["type"] === "factor")
 	{
 		ebeMacro = talentEbeData["value"].toString() + " * " + ebeMacro;
 	} else if (talentEbeData["type"] === "summand") {
 		ebeMacro += talentEbeData["value"].toString();
 	}
+	let rollMacro = generateTalentRollMacro("talent-ebe", nameInternal, nameUI, attributes, ebeMacro);
 
-	rollMacro +=
-		"@{gm_roll_opt} " +
-		"&{template:talent-ebe} " +
-		"{{name=" + nameUI + "}} " +
-		"{{wert=[[@{TaW_" + nameInternal + "}d1cs0cf2]]}} " +
-		"{{mod=[[ 0d1 + ?{Erleichterung (−) oder Erschwernis (+)|0}d1cs0cf2 + [[{0d1 + " + ebeMacro + ", 0d1}kh1]]d1cs0cf2 ]]}} " +
-		"{{stats=[[ " +
-			"[Eigenschaft 1:] [[@{Eigenschaft1" + nameInternal + "}]]d1cs0cf2 + " +
-			"[Eigenschaft 2:] [[@{Eigenschaft2" + nameInternal + "}]]d1cs0cf2 + " +
-			"[Eigenschaft 3:] [[@{Eigenschaft3" + nameInternal + "}]]d1cs0cf2" +
-			"]]}} " +
-		"{{roll=[[3d20cs<@{cs_talent}cf>@{cf_talent}]]}} " +
-		"{{result=[[0]]}} " +
-		"{{criticality=[[0]]}} " +
-		"{{critThresholds=[[[[@{cs_talent}]]d1cs0cf2 + [[@{cf_talent}]]d1cs0cf2]]}} " +
-		"{{ebe=[[{0d1 + " + ebeMacro + ", 0d1}kh1]]}} ";
 	debugLog(func, rollMacro);
 
 	// Execute Roll
 	results = await startRoll(rollMacro);
 	debugLog(func, "test: info:", info, "results:", results);
 
+
 	// Process Roll
-	var rollID = results.rollId;
+	let rollID = results.rollId;
 	results = results.results;
-	var TaW = results.wert.result;
-	var modTotal = results.mod.result;
 	var ebe = results.ebe.result;
-	var modOnly = modTotal - ebe;
-
-	var stats = [
-		results.stats.rolls[0].dice,
-		results.stats.rolls[1].dice,
-		results.stats.rolls[2].dice
-	];
-	var rolls = results.roll.rolls[0].results;
-	var success = results.critThresholds.rolls[0].dice;
-	var failure = results.critThresholds.rolls[1].dice;
-	/* Result
-	0	Failure
-	1	Success
-	*/
-	var result = 0;
-	/* Criticality
-	-3	Triple 20
-	-2	Double 20
-	 0	no double 1/20
-	+2	Double 1
-	+3	Triple 1
-	*/
-	var criticality = 0;
-
-	/*
-		Doppel/Dreifach-1/20-Berechnung
-		Vor der TaP*-Berechnung, da diese damit gegebenenfalls hinfällig wird
-	*/
-	{
-		let successes = 0;
-		let failures = 0;
-		for (roll of rolls)
-		{
-			if (roll <= success)
-			{
-				successes += 1;
-			} else if (roll >= failure) {
-				failures += 1;
-			}
-			if (successes >= 2)
-			{
-				criticality = successes;
-			} else if (failures >= 2) {
-				criticality = -failures;
-			}
-		}
-	}
-
-	/*
-		TaP*-Berechnung
-	*/
-	var effRolls = rolls;
-	var effTaW = TaW - modTotal;
-	var TaPstar = effTaW;
-
-	// Negativer TaW: |effTaW| zu Teilwürfen addieren
-	if (criticality >= 2)
-	{
-		TaPstar = TaW;
-		result = 1;
-	} else {
-		if (effTaW < 0)
-		{
-			for (roll in rolls)
-			{
-				effRolls[roll] = rolls[roll] + Math.abs(effTaW);
-			}
-			TaPstar = 0;
-		}
-
-		// TaP-Verbrauch für jeden Wurf
-		for (roll in effRolls)
-		{
-			TaPstar -= Math.max(0, effRolls[roll] - stats[roll]);
-		}
-
-		// Max. TaP* = TaW, mindestens aber 0
-		TaPstar = Math.min(Math.max(TaW, 0), TaPstar);
-
-		// Ergebnis an Doppel/Dreifach-20 anpassen
-		if (Math.abs(criticality) <= 1)
-		{
-			result = TaPstar < 0 ? 0 : 1;
-		} else if (criticality <= -2) {
-			result = 0;
-		}
-	}
+	var modOnly = results.mod.result - ebe;
+	let processedResult = getTalentRollResults(results);
 
 	finishRoll(
 		rollID,
 		{
 			mod: modOnly,
-			roll: TaPstar,
-			result: result,
-			criticality: criticality,
-			stats: stats.toString().replaceAll(",", "/")
+			roll: processedResult.TaPstar,
+			result: processedResult.result,
+			criticality: processedResult.criticality,
+			stats: processedResult.stats.toString().replaceAll(",", "/")
 		}
 	);
 });


### PR DESCRIPTION
Ich hab zuviel Freizeit und lasse andere Leute gerne über Diffs schauen.

Reines Refactor der Talents.js, um Codeduplikation zu entfernen, mit 2 Ausnahmen:

Beinhaltet die Fixes aus #137 
Entfernt ein pauschales console.log beim Würfeln von eBE Talenten