### PR TITLE
Bugfix/145 repräsentationswahl

### DIFF
--- a/Das_Schwarze_Auge_4-1/dev/js/magic.js
+++ b/Das_Schwarze_Auge_4-1/dev/js/magic.js
@@ -129,7 +129,7 @@ on(spells.map(spell => "clicked:" + spell + "-action").join(" "), (info) => {
 	var nameUI = spellsData[trigger]["ui"];
 	//Copy array, or we get a reference and modify the database
 	var stats = [...spellsData[trigger]["stats"]];
-	var spellRep = "z_" + nameInternal + "_representation";
+	var spellRep = trigger + "_representation";
 	debugLog(func, trigger, spellsData[trigger]);
 
 	var attrsToGet = [

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.css
@@ -1842,4 +1842,3 @@ upper left, upper right, lower right, lower left */
     color: var(--color-foreground) !important;
 }
 
-

--- a/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
+++ b/Das_Schwarze_Auge_4-1/dsa4_1_character_sheet_roll20.html
@@ -24082,7 +24082,7 @@ on(spells.map(spell => "clicked:" + spell + "-action").join(" "), (info) => {
 	var nameUI = spellsData[trigger]["ui"];
 	//Copy array, or we get a reference and modify the database
 	var stats = [...spellsData[trigger]["stats"]];
-	var spellRep = "z_" + nameInternal + "_representation";
+	var spellRep = trigger + "_representation";
 	debugLog(func, trigger, spellsData[trigger]);
 
 	var attrsToGet = [


### PR DESCRIPTION
Siehe #145

Alle Zauber, bei denen interner Name und Arraykey auseinander gingen, ließen keine zaubereigene Rep zu, da der falsche Attributsname verwendet wurde. Das hier behebt das.